### PR TITLE
rewrite/re-implement tab-drawer plugin

### DIFF
--- a/fw-child/resources/js/cdc.js
+++ b/fw-child/resources/js/cdc.js
@@ -188,7 +188,6 @@
       $('#coords-lat').val(options.coords.lat);
       $('#coords-lng').val(options.coords.lng);
       $('#coords-zoom').val(options.coords.zoom);
-      console.log('updated', options.coords);
     },
 
     invalidate_size: function () {

--- a/fw-child/resources/js/child-functions.js
+++ b/fw-child/resources/js/child-functions.js
@@ -10,9 +10,11 @@
       $(document).download_app();
     }
 
-    if ($('.query-page .tab-drawer').length) {
-      $('.query-page .tab-drawer').tab_drawer({
-        history: false,
+    if ($('.query-page #control-bar').length) {
+      $('.query-page #control-bar').tab_drawer({
+        history: {
+          enabled: false,
+        },
       });
     }
 

--- a/fw-child/resources/vendor/pe-tab-drawer/tab-drawer.scss
+++ b/fw-child/resources/vendor/pe-tab-drawer/tab-drawer.scss
@@ -7,19 +7,7 @@
 }
 
 .tab-drawer {
-  .tab-drawer-inner {
-    // position: relative;
-  }
-
   .tab-drawer-container {
-    // position: absolute;
-    // top: 0;
-    // left: 100%;
-    // height: 100%;
-    // width: 0;
-    // width: calc((100vw / 16) * 3);
-    // overflow: hidden;
-
     .tab-drawer {
       position: absolute;
       top: 0;

--- a/fw-child/resources/vendor/pe-tab-drawer/tab-drawer.scss
+++ b/fw-child/resources/vendor/pe-tab-drawer/tab-drawer.scss
@@ -1,14 +1,22 @@
+.tab-drawer-container {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  height: 100%;
+  width: 0;
+}
+
 .tab-drawer {
   .tab-drawer-inner {
     // position: relative;
   }
 
   .tab-drawer-container {
-    position: absolute;
-    top: 0;
-    left: 100%;
-    height: 100%;
-    width: 0;
+    // position: absolute;
+    // top: 0;
+    // left: 100%;
+    // height: 100%;
+    // width: 0;
     // width: calc((100vw / 16) * 3);
     // overflow: hidden;
 

--- a/fw-child/template/download/control-bar.php
+++ b/fw-child/template/download/control-bar.php
@@ -1,4 +1,4 @@
-<div id="control-bar" class="control-bar tab-drawer">
+<div id="control-bar" class="control-bar tab-drawer-tabs-container">
 	<?php 
 	
 		// LOGO
@@ -10,22 +10,22 @@
 	<a href="#menu" id="menu-trigger" class="d-block p-1"><i class="fas fa-align-left text-white"></i></a>
 	
 	<div id="control-bar-tabs" class="tab-drawer-tabs">
-		<a href="#data">
+		<a href="#data" class="tab-drawer-trigger">
 			<span class="cdc-icon"></span>
 			<span><?php _e ( 'Data', 'cdc' ); ?></span>
 		</a>
 		
-		<a href="#area">
+		<a href="#area" class="tab-drawer-trigger">
 			<span class="cdc-icon"></span>
 			<span><?php _e ( 'Area', 'cdc' ); ?></span>
 		</a>
 		
-		<a href="#details">
+		<a href="#details" class="tab-drawer-trigger">
 			<span class="cdc-icon"></span>
 			<span><?php _e ( 'Details', 'cdc' ); ?></span>
 		</a>
 		
-		<a href="#submit">
+		<a href="#submit" class="tab-drawer-trigger">
 			<span class="cdc-icon"></span>
 			<span><?php _e ( 'Submit', 'cdc' ); ?></span>
 		</a>

--- a/fw-child/template/learn/control-bar.php
+++ b/fw-child/template/learn/control-bar.php
@@ -1,13 +1,13 @@
 <div class="col-1">
-	<div id="control-bar" class="control-bar tab-drawer">
+	<div id="control-bar" class="control-bar tab-drawer-tabs-container">
 		
 		<div id="control-bar-tabs" class="tab-drawer-tabs">
-			<a href="#modules">
+			<a href="#modules" class="tab-drawer-trigger">
 				<span class="cdc-icon"></span>
 				<span><?php _e ( 'Modules', 'cdc' ); ?></span>
 			</a>
 			
-			<a href="#filters">
+			<a href="#filters" class="tab-drawer-trigger">
 				<span class="cdc-icon"></span>
 				<span><?php _e ( 'Filters', 'cdc' ); ?></span>
 			</a>

--- a/fw-child/template/map/control-bar.php
+++ b/fw-child/template/map/control-bar.php
@@ -1,4 +1,4 @@
-<div id="control-bar" class="control-bar tab-drawer">
+<div id="control-bar" class="control-bar tab-drawer-tabs-container">
 	<?php 
 	
 		// LOGO
@@ -10,22 +10,22 @@
 	<a href="#menu" id="menu-trigger" class="d-block p-1"><i class="fas fa-align-left text-white"></i></a>
 	
 	<div id="control-bar-tabs" class="tab-drawer-tabs">
-		<a href="#data">
+		<a href="#data" class="tab-drawer-trigger">
 			<span class="cdc-icon"></span>
 			<span><?php _e ( 'Data', 'cdc' ); ?></span>
 		</a>
 		
-		<a href="#location">
+		<a href="#location" class="tab-drawer-trigger">
 			<span class="cdc-icon"></span>
 			<span><?php _e ( 'Location', 'cdc' ); ?></span>
 		</a>
 		
-		<a href="#display">
+		<a href="#display" class="tab-drawer-trigger">
 			<span class="cdc-icon"></span>
 			<span><?php _e ( 'Display', 'cdc' ); ?></span>
 		</a>
 		
-		<a href="#download">
+		<a href="#download" class="tab-drawer-trigger">
 			<span class="cdc-icon"></span>
 			<span><?php _e ( 'Download', 'cdc' ); ?></span>
 		</a>

--- a/fw-child/template/news/control-bar.php
+++ b/fw-child/template/news/control-bar.php
@@ -1,8 +1,8 @@
 <div class="col-1">
-	<div id="control-bar" class="control-bar tab-drawer">
+	<div id="control-bar" class="control-bar tab-drawer-tabs-container">
 		
 		<div id="control-bar-tabs" class="tab-drawer-tabs">
-			<a href="#filters">
+			<a href="#filters" class="tab-drawer-trigger">
 				<span class="cdc-icon"></span>
 				<span><?php _e ( 'Filters', 'cdc' ); ?></span>
 			</a>


### PR DESCRIPTION
this PR includes significant changes to the tab-drawer JS plugin i.e. the control bar on map/download/news/learn pages. it now uses a 'path' array to define UX behaviours rather than evaluating elements on the fly.

there are also minor updates to the template files for pages that use this plugin.