### PR TITLE
fix bug calling get_layer when there's no variable

### DIFF
--- a/fw-child/resources/js/download.js
+++ b/fw-child/resources/js/download.js
@@ -709,7 +709,11 @@
           query: options.query,
           do_history: do_history,
           callback: function () {
-            if (options.query.var != null) {
+            if (
+              options.query.var != null &&
+              options.query.var != 'null' &&
+              options.var_data != null
+            ) {
               console.log('get layer');
               $(document).cdc_app(
                 'maps.get_layer',


### PR DESCRIPTION
fix for download page bug pointed out by @xfrenette-crim:

>- Go to the "download" page
>- Once the page has loaded and the URL has been modified, reload the page
>- Once the page has reloaded, manually move the map
>- A JavaScript error is triggered "TypeError: Cannot read properties of null (reading 'slug')".

download.js was validating the `query.var` property incorrectly and calling the `get_layer` map function when it wasn't needed