### PR TITLE
H7 feb16 query bugs

### DIFF
--- a/framework/resources/functions/builder/front-end/block/content/query.php
+++ b/framework/resources/functions/builder/front-end/block/content/query.php
@@ -77,6 +77,11 @@ if ( $element['inputs']['type'] == 'posts' ) {
 	
 	// dumpit ( $args );
 	
+	// random seed
+	
+	if ( $args['orderby'] == 'rand' )
+		$args['orderby'] = 'RAND(' . mt_rand ( 100000, 999999 ) . ')';
+	
 	// run the query
 	
 	$element['query'] = new WP_Query ( $args );

--- a/framework/resources/js/query.js
+++ b/framework/resources/js/query.js
@@ -276,6 +276,9 @@
 				
 			})
 			
+			// always set the page back to 1
+			options.args.paged = 1
+			
 			// console.log('new args', options.args)
 			
 			plugin.do_query()

--- a/fw-child/template/download/controls/data-variable.php
+++ b/fw-child/template/download/controls/data-variable.php
@@ -10,11 +10,11 @@
 				
 				<div id="var-select-query" class="fw-query-object"
 					data-args='{
-						"posts_per_page":15,
+						"posts_per_page": 15,
 						"post_type": [ "variable" ],
-						"orderby":"rand",
-						"order":"asc",
-						"post_status":"publish"
+						"orderby": "RAND(<?php echo mt_rand ( 100000, 999999 ); ?>)",
+						"order": "asc",
+						"post_status": "publish"
 					}'
 				>
 					

--- a/fw-child/template/map/controls/data-variable.php
+++ b/fw-child/template/map/controls/data-variable.php
@@ -12,7 +12,7 @@
 					data-args='{
 						"posts_per_page":15,
 						"post_type": [ "variable" ],
-						"orderby":"rand",
+						"orderby": "RAND(<?php echo mt_rand ( 100000, 999999 ); ?>)",
 						"order":"asc",
 						"post_status":"publish"
 					}'


### PR DESCRIPTION
adds a RAND(12345) seed number to the query parameters to fix this issue found by @perronld:

>Issue when selecting a variable. The ordering is random, so the pagination doesn't make any sense.
>`args[orderby]: rand`

also found a pagination bug in the parent theme that stopped the query resetting to page 1 when changing filters