### PR TITLE
CLIM-476 - Add a "Download" button in "Explore Maps"

### DIFF
--- a/fw-child/resources/js/map.js
+++ b/fw-child/resources/js/map.js
@@ -852,6 +852,18 @@
           .val($(this).attr('data-scheme-id'))
           .trigger('change');
       });
+      
+      // "Download" button
+
+      // Handle of the click on the "Download" button of the "Share" tab.
+      // Takes the current page's query and builds a URL for the "Download Data" page. That way, some of the inputs of
+      // the "Download" page are pre-filled.
+      $('#download-btn').on('click', function (event) {
+        event.preventDefault();
+        const base_href = this.href;
+        const query_string = $(document).cdc_app('query.obj_to_url', options.query, null);
+        window.location.href = base_href + query_string + '#data'; // Pre-open the "Data" tab on the "Download" page
+      });
 
       // HISTORY
 

--- a/fw-child/template/map/controls/download.php
+++ b/fw-child/template/map/controls/download.php
@@ -32,51 +32,17 @@
 					
 				</div>
 				
-				<h6 class="all-caps text-secondary mx-4 my-3"><?php _e ( 'Export Data', 'cdc' ); ?></h6>
+				<h6 class="all-caps text-secondary mx-4 my-3"><?php _e ( 'Download Data', 'cdc' ); ?></h6>
 				
-				<div id="map-control-export" class="map-control-item conditional-trigger bg-white me-2">
-					<div class="mb-3">
-					
-						<label for="download-area" class="form-label d-block h6 all-caps text-gray-600"><?php _e ( 'Data Area', 'cdc' ); ?></label>
-						
-						<div class="form-check">
-							<input class="form-check-input" type="radio" name="download-area" id="download-area-select" checked>
-							<label class="form-check-label" for="download-area-select"><?php _e ( 'Select regions', 'cdc' ); ?></label>
-						</div>
-						
-						<div class="form-check">
-							<input class="form-check-input" type="radio" name="download-area" id="download-area-draw">
-							<label class="form-check-label" for="download-area-draw"><?php _e ( 'Draw custom region', 'cdc' ); ?></label>
-						</div>
-						
-						<div class="form-check">
-							<input class="form-check-input" type="radio" name="download-area" id="download-area-custom" data-conditional="#download-area-shapefile">
-							<label class="form-check-label" for="download-area-custom"><?php _e ( 'Custom shapefile', 'cdc' ); ?></label>
-						</div>
-						
-						<div id="download-area-shapefile" class="bg-gray-200 p-2">
-							<label for="download-area-shapefile-input" class="form-label"><?php _e ( 'Drop your GeoJSON file here to upload', 'cdc' ); ?></label>
-							<input class="form-control form-control-sm" id="download-area-shapefile-input" type="file">
-						</div>
-					</div>
-					
-					<div class="mb-3">
-						<label for="download-format" class="form-label d-block h6 all-caps text-gray-600"><?php _e ( 'Export Format', 'cdc' ); ?></label>
-						
-						<div class="btn-group w-100">
-							<input type="radio" class="btn-check" name="download-format" id="download-format-csv" value="csv" autocomplete="off" checked>
-							<label class="btn btn-outline-gray-400" for="download-format-csv"><?php _e ( 'CSV', 'cdc' ); ?></label>
-							
-							<input type="radio" class="btn-check" name="download-format" id="download-format-json" value="json" autocomplete="off">
-							<label class="btn btn-outline-gray-400" for="download-format-json"><?php _e ( 'JSON', 'cdc' ); ?></label>
-							
-							<input type="radio" class="btn-check" name="download-format" id="download-format-netcdf" value="netcdf" autocomplete="off">
-							<label class="btn btn-outline-gray-400" for="download-format-netcdf"><?php _e ( 'NetCDF', 'cdc' ); ?></label>
-						</div>
-					</div>
-					
-					<a href="#" class="btn btn-secondary d-block" id="process-download"><?php _e ( 'Process & Download', 'cdc' ); ?></a>
-					
+				<div id="map-control-download" class="map-control-item conditional-trigger bg-white me-2">
+					<p><?php _e ( 'You can customize and download the data displayed on this map.', 'cdc' ); ?></p>
+					<?php
+					$dl_slug = $GLOBALS['fw']['current_lang_code'] == 'fr' ? 'telechargement' : 'download';
+					?>
+					<a href="<?php echo home_url ( $dl_slug ); ?>" class="btn btn-secondary d-block" id="download-btn">
+						<span class="btn-icon"><i class="far fa-download"></i></span>
+						<span class="btn-text"><?php _e ( 'Download', 'cdc' ); ?></span>
+					</a>
 				</div>
 				
 			</div>


### PR DESCRIPTION
In the _Download_ tab of the _Explore Maps_ page, it was decided to replace the _Export Data_ section with a single button that leads to the _Download Data_ page. This PR adds this button.

**Before**

<img src="https://github.com/CanadianClimateDataPortal/climatedata-wp-theme/assets/159493515/0555f8a8-12cf-42ed-aec5-4429dd0d9e87" width="200">

**After**

<img src="https://github.com/CanadianClimateDataPortal/climatedata-wp-theme/assets/159493515/654f45e0-261f-4f23-b8e7-fda0296850b3" width="200">

<hr>

When clicking on the button, we want the user to be sent to the _Download Data_ page, but we also want this page to be prefilled with the values the user selected in this page. For example, we want the user's selected variable to "stay" selected.

### Implementation

- The _href_ of the button is the _Download Data_ URL, without any query string.
- The `query` object of the current page is transformed to a URL query string (using `$(document).cdc_app('query.obj_to_url', query)`)
- The JS builds a URL from the button's href and the built query string, and redirects to it.

### Note
The text above the button was written by me. It needs to be officially defined and translated. But it will be done in a future and separate PR.
