### PR TITLE
Add a Pull Request template, and pull request documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+
+> First make sure to read the ["Pull requests process" in CONTRIBUTING.md](https://github.com/CanadianClimateDataPortal/climatedata-wp-theme/blob/main/CONTRIBUTING.md#pull-requests-process). Remove this comment afterward.
+
+_(Replace this paragraph with a description of changes introduced by your pull request. If applicable, don't
+hesitate to include context for the changes, description of incorrect behaviour fixed, reasons for a new feature, etc.)_
+
+## Related ticket
+
+_(If a ticket in your task manager is linked to this PR, replace this line with the URL to the ticket. If not applicable,
+you can remove this whole section.)_

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 ## Description
 
-> First make sure to read the ["Pull requests process" in CONTRIBUTING.md](https://github.com/CanadianClimateDataPortal/climatedata-wp-theme/blob/main/CONTRIBUTING.md#pull-requests-process). Remove this comment afterward.
-
 _(Replace this paragraph with a description of changes introduced by your pull request. If applicable, don't
 hesitate to include context for the changes, description of incorrect behaviour fixed, reasons for a new feature, etc.)_
 
@@ -9,3 +7,16 @@ hesitate to include context for the changes, description of incorrect behaviour 
 
 _(If a ticket in your task manager is linked to this PR, replace this line with the URL to the ticket. If not applicable,
 you can remove this whole section.)_
+
+> Make sure to read the ["Pull requests process" in CONTRIBUTING.md](https://github.com/CanadianClimateDataPortal/climatedata-wp-theme/blob/main/CONTRIBUTING.md#pull-requests-process).
+> 
+> Main points:
+> * The assigned reviewer(s) must always _submit_ a review (not simply add a comment).
+> * If the PR is "Approved", the creator of the PR must then:
+>   * Implement the changes in the reviewer's comments, if applicable, and mark them as "Resolved".
+>   * Squash and merge the branch.
+>   * Delete the branch.
+> * If the PR is "Request Changes", the creator of the PR must then:
+>   * Update the code as requested.
+>   * Re-request a review from the reviewer.
+>   * NOT mark the comments as "Resolved", the reviewer will.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,32 @@
 ## Description
 
-_(Replace this paragraph with a description of changes introduced by your pull request. If applicable, don't
-hesitate to include context for the changes, description of incorrect behaviour fixed, reasons for a new feature, etc.)_
+(Replace this paragraph with a description of changes introduced by your pull
+request. If applicable, don't hesitate to include context for the changes,
+description of incorrect behaviour fixed, reasons for a new feature, etc.)
 
 ## Related ticket
 
-_(If a ticket in your task manager is linked to this PR, replace this line with the URL to the ticket. If not applicable,
-you can remove this whole section.)_
+(If a ticket in your task manager is linked to this PR, replace this paragraph
+with the URL to the ticket. If not applicable, you can remove this whole
+section.)
 
-> Make sure to read the ["Pull requests process" in CONTRIBUTING.md](https://github.com/CanadianClimateDataPortal/climatedata-wp-theme/blob/main/CONTRIBUTING.md#pull-requests-process).
+
+> Make sure to read the *Pull requests process* in CONTRIBUTING.md.
 > 
 > Main points:
-> * The assigned reviewer(s) must always _submit_ a review (not simply add a comment).
+> 
+> * The assigned reviewer(s) must always *submit* a review (not simply add a
+>   comment).
+>
 > * If the PR is "Approved", the creator of the PR must then:
->   * Implement the changes in the reviewer's comments, if applicable, and mark them as "Resolved".
+>   * Implement the changes in the reviewer's comments, if applicable, and mark
+>     them as "Resolved".
 >   * Squash and merge the branch.
 >   * Delete the branch.
+> 
 > * If the PR is "Request Changes", the creator of the PR must then:
 >   * Update the code as requested.
 >   * Re-request a review from the reviewer.
 >   * NOT mark the comments as "Resolved", the reviewer will.
+> 
+> (You can keep or remove this block, as you wish.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,9 @@
 
 ### Submitting a pull request
 
-When submitting a pull request, make sure to provide a meaningful description. Depending on what your update does, don't hesitate to add context, to
-describe the current (incorrect) behavior, to describe what modification your update brings, etc.
+When submitting a pull request, make sure to provide a meaningful description. Depending on what your update does, don't
+hesitate to add context, to describe the current (incorrect) behavior, to describe what modification your update brings,
+etc.
 
 The PR's description must be written in English.
 
@@ -45,12 +46,16 @@ Your responsibilities are then:
 4. Delete the branch (but never delete the `demo`, `demo-2.0` and `main` branches).
 
 Notes:
-* If multiple reviewers were assigned, you should wait for all of them to submit their review, unless it was agreed beforehand that only some of the reviews are required.
-* Make sure to read the comments left by the reviewer(s). Even if the PR is approved, there might be requests for minor changes.
+* If multiple reviewers were assigned, you should wait for all of them to submit their review, unless it was agreed
+  beforehand that only some of the reviews are required.
+* Make sure to read the comments left by the reviewer(s). Even if the PR is approved, there might be requests for minor
+  changes.
 * Beside the requested minor changes, don't update your code after the PR has been approved.
-* Always _Squash and Merge_ your branch. If you think that your PR should not be squashed, validate with the project's tech lead.
-* If a requested change needs more discussion, discuss it in the comment's thread. If a discussion happened outside of GitHub
-  (ex: by video call), write in the comment's thread a summary of what was discussed, or add a link to the external conversation if applicable (ex: a Slack exchange).
+* Always _Squash and Merge_ your branch. If you think that your PR should not be squashed, validate with the project's
+  tech lead.
+* If a requested change needs more discussion, discuss it in the comment's thread. If a discussion happened outside of
+  GitHub (ex: by video call), write in the comment's thread a summary of what was discussed, or add a link to the
+  external conversation if applicable (ex: a Slack exchange).
 
 #### If your pull request is marked "Request changes" by the reviewer(s)
 
@@ -60,11 +65,12 @@ Your responsibilities are:
 2. Request again a review from the reviewer(s) ([see how to](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review)).
 
 Notes:
-* When ready for another review, use the "Re-request review" button beside the reviewer's name. Don't simply add a comment
-  nor simply send a message to the reviewer.
+* When ready for another review, use the "Re-request review" button beside the reviewer's name. Don't simply add a
+  comment nor simply send a message to the reviewer.
 * **_Don't_** mark a reviewer's comments as "Resolved" after you updated your code. The reviewer will need to know
   what was the comment before re-validating it. The reviewer will "resolve" the comment once it's considered resolved.
-  If you want to show that you have now "resolved" the comment, you can add a reaction (ex: 👍) or a message in the comment's thread.
+  If you want to show that you have now "resolved" the comment, you can add a reaction (ex: 👍) or a message in the
+  comment's thread.
 * Once your PR is approved, follow the instructions above (in "_If your pull request is approved by the reviewer(s)_").
 
 ### Reviewing a pull request
@@ -74,7 +80,8 @@ If you are assigned a PR to review, your responsibilities are:
 1. Make sure the code follows the best practices and that it works as expected (test the code on your environment).
 2. Add comments where modifications are desired.
 3. Submit your review:
-    * "Approved" if no changes are requested, or the requested changes are minor enough that you don't need to review them.
+    * "Approved" if no changes are requested, or the requested changes are minor enough that you don't need to review
+      them.
     * "Request Changes" if you would like to review how the changes will be implemented.
 
 If you are requested to *re*-review a PR, your responsibilities are:
@@ -85,6 +92,7 @@ If you are requested to *re*-review a PR, your responsibilities are:
 4. Submit your review ("Approved" or "Request Changes").
 
 Notes:
-* Always _submit_ a review ("Approved" or "Request Changes"), don't simply add a comment. Else, it complicates the PR management if we cannot easily see what is reviewed or not.
-  Don't hesitate to use "Request Changes".
-* If a discussion happened outside a comment's thread (ex: a video call), update the thread to include a summary of what was discussed, or add a link to this outside discussion (ex: a Slack exchange).
+* Always _submit_ a review ("Approved" or "Request Changes"), don't simply add a comment. Else, it complicates the PR
+  management if we cannot easily see what has been reviewed or not. Don't hesitate to use "Request Changes".
+* If a discussion happened outside a comment's thread (ex: a video call), update the thread to include a summary of what
+  was discussed, or add a link to this outside discussion (ex: a Slack exchange).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,3 +23,44 @@
 <em>Refer to the image below for graphically represented Git workflow.</em>
 
 ![Branching strategy](branching.png)
+
+## Pull requests process
+
+When submitting a pull request, make sure to provide a meaningful description. Depending on what your update does, don't hesitate to add context, to
+describe the current (incorrect) behavior, to describe what modification your update brings, etc.
+
+If the PR is related to a specific ticket, include a link to the ticket.
+
+### If your pull request is "approved" by the reviewer
+
+A PR will be approved when there are no changes requested, or when there are only minor changes requested (ex: related to code style or comments, code changes that don't affect the general logic, etc.).
+
+The person that opened the PR will then be responsible to:
+1. Update the code as requested, if changes were requested.
+2. Mark as "resolved" all pending discussions.
+3. **_Squash and Merge_** the PR.
+4. Delete the branch, if it's a _feature_ or _fix_ branch.
+
+**Notes**:
+* Make sure to read the comments left by the reviewer. Even if the PR is approved, there might be requests for minor changes.
+* Beside the requested minor changes, don't update your code after the PR has been approved.
+* Always _Squash and Merge_, unless exception.
+* If a requested change needs more discussion, discuss under the comment left by the reviewer. If a discussion happened outside of GitHub
+  (ex: by video call), write in the comment's discussion a summary of what was discussed.
+
+### If your pull request is marked "Request changes" by the reviewer
+
+A PR will be marked "Request changes" when requested changes are significant enough that the necessary updates would
+need a new review.
+
+The person that opened the PR will then be responsible to:
+1. Update the code as requested (but don't "resolve" the reviewer's comments).
+2. Request again a review from the reviewer (using the button beside the reviewer's name).
+
+**Notes**:
+* When ready for another review, use the "Re-request review" button beside the reviewer's name. Don't simply add a comment
+  nor simply send a message to the reviewer.
+* **_Don't_** mark the reviewer's comments as "Resolved" after you updated your code. The reviewer will need to know
+  what was the comment before re-validating it. The reviewer will "resolve" the conversation once it's considered resolved.
+  If you want to show that you have now "resolved" the comment, you can add a reaction (ex: 👍) or a comment to the comment.
+* Once your PR is approved, follow the instructions in "_If your pull request is approved_".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,41 +26,65 @@
 
 ## Pull requests process
 
+### Submitting a pull request
+
 When submitting a pull request, make sure to provide a meaningful description. Depending on what your update does, don't hesitate to add context, to
 describe the current (incorrect) behavior, to describe what modification your update brings, etc.
 
+The PR's description must be written in English.
+
 If the PR is related to a specific ticket, include a link to the ticket.
 
-### If your pull request is "approved" by the reviewer
+#### If your pull request is "approved" by the reviewer(s)
 
-A PR will be approved when there are no changes requested, or when there are only minor changes requested (ex: related to code style or comments, code changes that don't affect the general logic, etc.).
+Your responsibilities are then:
 
-The person that opened the PR will then be responsible to:
 1. Update the code as requested, if changes were requested.
-2. Mark as "resolved" all pending discussions.
+2. Mark as "resolved" all pending comments.
 3. **_Squash and Merge_** the PR.
-4. Delete the branch, if it's a _feature_ or _fix_ branch.
+4. Delete the branch (but never delete the `demo`, `demo-2.0` and `main` branches).
 
-**Notes**:
-* Make sure to read the comments left by the reviewer. Even if the PR is approved, there might be requests for minor changes.
+Notes:
+* If multiple reviewers were assigned, you should wait for all of them to submit their review, unless it was agreed beforehand that only some of the reviews are required.
+* Make sure to read the comments left by the reviewer(s). Even if the PR is approved, there might be requests for minor changes.
 * Beside the requested minor changes, don't update your code after the PR has been approved.
-* Always _Squash and Merge_, unless exception.
-* If a requested change needs more discussion, discuss under the comment left by the reviewer. If a discussion happened outside of GitHub
-  (ex: by video call), write in the comment's discussion a summary of what was discussed.
+* Always _Squash and Merge_ your branch. If you think that your PR should not be squashed, validate with the project's tech lead.
+* If a requested change needs more discussion, discuss it in the comment's thread. If a discussion happened outside of GitHub
+  (ex: by video call), write in the comment's thread a summary of what was discussed, or add a link to the external conversation if applicable (ex: a Slack exchange).
 
-### If your pull request is marked "Request changes" by the reviewer
+#### If your pull request is marked "Request changes" by the reviewer(s)
 
-A PR will be marked "Request changes" when requested changes are significant enough that the necessary updates would
-need a new review.
+Your responsibilities are:
 
-The person that opened the PR will then be responsible to:
-1. Update the code as requested (but don't "resolve" the reviewer's comments).
-2. Request again a review from the reviewer (using the button beside the reviewer's name).
+1. Update the code as requested (but don't "resolve" the reviewers comments).
+2. Request again a review from the reviewer(s) ([see how to](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews#re-requesting-a-review)).
 
-**Notes**:
+Notes:
 * When ready for another review, use the "Re-request review" button beside the reviewer's name. Don't simply add a comment
   nor simply send a message to the reviewer.
-* **_Don't_** mark the reviewer's comments as "Resolved" after you updated your code. The reviewer will need to know
-  what was the comment before re-validating it. The reviewer will "resolve" the conversation once it's considered resolved.
-  If you want to show that you have now "resolved" the comment, you can add a reaction (ex: 👍) or a comment to the comment.
-* Once your PR is approved, follow the instructions in "_If your pull request is approved_".
+* **_Don't_** mark a reviewer's comments as "Resolved" after you updated your code. The reviewer will need to know
+  what was the comment before re-validating it. The reviewer will "resolve" the comment once it's considered resolved.
+  If you want to show that you have now "resolved" the comment, you can add a reaction (ex: 👍) or a message in the comment's thread.
+* Once your PR is approved, follow the instructions above (in "_If your pull request is approved by the reviewer(s)_").
+
+### Reviewing a pull request
+
+If you are assigned a PR to review, your responsibilities are:
+
+1. Make sure the code follows the best practices and that it works as expected (test the code on your environment).
+2. Add comments where modifications are desired.
+3. Submit your review:
+    * "Approved" if no changes are requested, or the requested changes are minor enough that you don't need to review them.
+    * "Request Changes" if you would like to review how the changes will be implemented.
+
+If you are requested to *re*-review a PR, your responsibilities are:
+
+1. Review every comment you left and make sure the correct changes have been applied.
+2. Mark as "Resolved" comments that have been resolved.
+3. Add more comments, if required.
+4. Submit your review ("Approved" or "Request Changes").
+
+Notes:
+* Always _submit_ a review ("Approved" or "Request Changes"), don't simply add a comment. Else, it complicates the PR management if we cannot easily see what is reviewed or not.
+  Don't hesitate to use "Request Changes".
+* If a discussion happened outside a comment's thread (ex: a video call), update the thread to include a summary of what was discussed, or add a link to this outside discussion (ex: a Slack exchange).


### PR DESCRIPTION
## Description

When working with multiple developers, the _Pull Request process_ (reviewing, approving, merging) should be documented to ensure the same process is followed by everyone to prevent any miscommunication and ensure a more efficient process.

This PR adds documentation about the Pull Request process in CONTRIBUTING.md. It also introduces a simple _GitHub Pull Request template_ for the future PRs.

Note that GitHub requires that the Pull Request template be in the `main` branch, which is why this PR is to be merged in `main`.