### PR TITLE
CLIM-697: Add CookieYes script tag to head for each language

### DIFF
--- a/climate-data-ca/default_config.php
+++ b/climate-data-ca/default_config.php
@@ -11,6 +11,12 @@ function custom_global_vars()
     $vars['analytics_ua_en'] = "G-CPGH39EQSH"; // GA4 account valid for dev-(en|fr).climatedata.ca
     $vars['analytics_ua_fr'] = "G-CPGH39EQSH";
     $vars['googletag_id'] = "GTM-NJ7L4NR";
+
+    // CookieYes site ID (as found in the required script tag URL: https://cdn-cookieyes.com/client_data/<ID>/script.js)
+    // If empty, no CookieYes script will be included.
+    $vars['cookieyes_id_fr'] = ""; // ID for French site
+    $vars['cookieyes_id_en'] = ""; // ID for English site
+
     $vars['ga_cross_domain'] = "";
     $vars['feedback_email'] = "nullbox@climatedata.ca";
     $vars['training_email'] = "nullbox@climatedata.ca";

--- a/climate-data-ca/functions.php
+++ b/climate-data-ca/functions.php
@@ -195,6 +195,33 @@ function child_theme_enqueue()
 
 add_action('wp_enqueue_scripts', 'child_theme_enqueue');
 
+/**
+ * Insert the CookieYes script tag in the head.
+ *
+ * CookieYes does provide a WordPress plugin that automatically includes the required script tag, but it supports only
+ * one ID. Since we use different domains for each language, and that CookieYes requires a different ID for different
+ * domains, the plugin is replaced by this hook that can insert a different ID for each language (i.e. domain).
+ */
+add_action('wp_head',
+
+    /**
+     * Add the CookieYes language specific script tag to the head.
+     *
+     * The inserted script tag requires an ID in the `cookieyes_id_<lang>` entry in the global 'vars' array. If the
+     * entry is not defined or empty, no script tag is inserted.
+     */
+    function () {
+        $lang = $GLOBALS['vars']['current_lang'];
+        $id_key = 'cookieyes_id_' . $lang;
+        $cookieyes_id = $GLOBALS['vars'][$id_key] ?? '';
+
+        if ( !empty( $cookieyes_id ) ) {
+            echo '<script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/' . $cookieyes_id . '/script.js"></script>';
+        }
+    },
+    1
+);
+
 //
 // ADMIN JS
 //


### PR DESCRIPTION
## Description

### Context
We use _CookieYes_ to allow users to accept or refuse cookies. To enable CookieYes, a &lt;script> tag must be inserted in the &lt;head>. A different script tag needs to be inserted for each domain (i.e. each language).

### This PR
* Add the CookieYes script tag to the &lt;head>.
* Allow the developer to specify the domain's ID (used in the script tag URL) for each language (configurable for each environment).
* Allow to _not_ insert the CookieYes tag on staging and dev environments (by not specifying the site ID).

## Related ticket
https://ccdpwiki.atlassian.net/browse/CLIM-697