### PR TITLE
CLIM-698: Add CookieYes script tag

### DIFF
--- a/fw-child/default_config.php
+++ b/fw-child/default_config.php
@@ -12,6 +12,12 @@ function custom_global_vars()
     $vars['analytics_ua_fr'] = "G-CPGH39EQSH";
     $vars['googletag_id'] = "GTM-NJ7L4NR";
     $vars['ga_cross_domain'] = "";
+
+    // CookieYes site ID (as found in the required script tag URL: https://cdn-cookieyes.com/client_data/<ID>/script.js)
+    // If empty, no CookieYes script will be included.
+    $vars['cookieyes_id_fr'] = ""; // ID for French site
+    $vars['cookieyes_id_en'] = ""; // ID for English site
+
     $vars['feedback_email'] = "nullbox@climatedata.ca";
     $vars['training_email'] = "nullbox@climatedata.ca";
     $vars['mailchimp_api_key'] = "";

--- a/fw-child/functions.php
+++ b/fw-child/functions.php
@@ -462,6 +462,33 @@ add_action ( 'fw_before_footer', function() {
 
 } );
 
+/**
+ * Insert the CookieYes script tag in the head.
+ *
+ * CookieYes does provide a WordPress plugin that automatically includes the required script tag, but it supports only
+ * one ID. Since we use a different domain for each language, and since CookieYes requires a different ID for different
+ * domains, the plugin is replaced by this hook that can insert a different ID for each language (i.e. domain).
+ */
+add_action('wp_head',
+
+	/**
+	 * Output the CookieYes language specific script tag.
+	 *
+	 * The inserted script tag requires an ID in the `cookieyes_id_<lang>` entry in the global 'vars' array. If the
+	 * entry is not defined or empty, no script tag is inserted.
+	 */
+	function () {
+		$lang = $GLOBALS['fw']['current_lang_code'];
+		$id_key = 'cookieyes_id_' . $lang;
+		$cookieyes_id = $GLOBALS['vars'][$id_key] ?? '';
+
+		if ( !empty( $cookieyes_id ) ) {
+			echo '<script id="cookieyes" type="text/javascript" src="https://cdn-cookieyes.com/client_data/' . $cookieyes_id . '/script.js"></script>';
+		}
+	},
+	1
+);
+
 //
 // VARIABLES OFFCANVAS
 //


### PR DESCRIPTION
## Context

The site will use _CookieYes_ for cookies acceptance. _CookieYes_ is added to the site by including a &lt;script> tag in the header. The script's URL contains an ID unique to the domain. Example: `https://cdn-cookieyes.com/client_data/<ID>/script.js`

Since we have a different domain for each language, we need to insert a different script tag for each language.

There exists a _CookieYes_ WordPress plugin, but it doesn't support different IDs for the same WordPress installation. So instead of using the plugin, we add the script tag programmatically.

## This PR

This PR contains the code to insert the script tag programmatically.

The ID used in the script's URL is defined in `default_config.php`. The script tag is then inserted in the head using a WordPress hook.

## Related ticket

https://ccdpwiki.atlassian.net/browse/CLIM-698