### PR TITLE
refs #66259: Make interactive public for Motion.page only.  Allow edit.

### DIFF
--- a/fw-child/functions.php
+++ b/fw-child/functions.php
@@ -541,22 +541,22 @@ function cdc_enable_block_editor( $use_block_editor, $post_type ) {
 }
 
 /**
- * Returns a an array of args making interactive posts public if loaded by Motion.page editor.
+ * Updates the `interactive` post type arguments to make it public if loaded by the motion.page editor.
  * 
  * @param array   $args Array of arguments for registering a post type.
  * @param string  $post_type Post type key.
  * 
  * @return array  Array of arguments for registering a post type.
  */
-function make_interactive_cpt_public_for_motion_page( $args, $post_type ) {
+function cdc_make_interactive_cpt_public_for_motion_page( $args, $post_type ) {
 	if ( $post_type === 'interactive' ) {
 		// Check if the request is coming from Motion.page
-        if ( isset( $_GET['motionpage_iframe'] ) && $_GET['motionpage_iframe'] == 'true' ) {
+		if ( isset( $_GET['motionpage_iframe'] ) && $_GET['motionpage_iframe'] == 'true' ) {
 			$args['public'] = true;
-            $args['publicly_queryable'] = true;
-        }
-    }
-    return $args;
+			$args['publicly_queryable'] = true;
+		}
+	}
+	return $args;
 }
 
 /**
@@ -590,7 +590,7 @@ add_action ( 'admin_menu', 'remove_comments_admin_menu' );
 add_action ( 'wp_before_admin_bar_render', 'remove_comments_admin_bar' );
 add_filter ( 'use_block_editor_for_post_type', 'cdc_enable_block_editor', 10, 2 );
 add_filter ( 'manage_post_posts_columns', 'cdc_manage_post_columns', 10, 1 );
-add_filter ( 'register_post_type_args', 'make_interactive_cpt_public_for_motion_page', 10, 2 );
+add_filter ( 'register_post_type_args', 'cdc_make_interactive_cpt_public_for_motion_page', 10, 2 );
 
 //
 // MISC

--- a/fw-child/functions.php
+++ b/fw-child/functions.php
@@ -94,7 +94,8 @@ function child_theme_enqueue() {
 	wp_register_style ( 'gutenberg', $child_theme_dir . 'resources/css/gutenberg.css', null, null );
 	wp_enqueue_style ( 'child-style', $child_theme_dir . 'style.css', NULL, NULL, 'all' );
 
-	if ( is_singular ( 'resource' ) ) {
+	// Load WP native styles for resource and interactive posts
+	if ( is_singular ( 'resource' ) || is_singular ( 'interactive' ) ) {
 		wp_enqueue_style ( 'wp-block-library' );
 		wp_enqueue_style ( 'gutenberg' );
 		wp_enqueue_style ( 'global-styles' );
@@ -540,6 +541,25 @@ function cdc_enable_block_editor( $use_block_editor, $post_type ) {
 }
 
 /**
+ * Returns a an array of args making interactive posts public if loaded by Motion.page editor.
+ * 
+ * @param array   $args Array of arguments for registering a post type.
+ * @param string  $post_type Post type key.
+ * 
+ * @return array  Array of arguments for registering a post type.
+ */
+function make_interactive_cpt_public_for_motion_page( $args, $post_type ) {
+	if ( $post_type === 'interactive' ) {
+		// Check if the request is coming from Motion.page
+        if ( isset( $_GET['motionpage_iframe'] ) && $_GET['motionpage_iframe'] == 'true' ) {
+			$args['public'] = true;
+            $args['publicly_queryable'] = true;
+        }
+    }
+    return $args;
+}
+
+/**
  * Unregisters default taxonomies that are not used.
  *
  * @return void
@@ -570,6 +590,7 @@ add_action ( 'admin_menu', 'remove_comments_admin_menu' );
 add_action ( 'wp_before_admin_bar_render', 'remove_comments_admin_bar' );
 add_filter ( 'use_block_editor_for_post_type', 'cdc_enable_block_editor', 10, 2 );
 add_filter ( 'manage_post_posts_columns', 'cdc_manage_post_columns', 10, 1 );
+add_filter ( 'register_post_type_args', 'make_interactive_cpt_public_for_motion_page', 10, 2 );
 
 //
 // MISC

--- a/fw-child/single-interactive.php
+++ b/fw-child/single-interactive.php
@@ -1,0 +1,13 @@
+<?php
+// This file is essential to edit interactive posts with the motion.page plugin.
+
+get_header();
+
+if ( have_posts() ) {
+	while ( have_posts() ) {
+		the_post();
+		the_content();
+	}
+}
+
+get_footer();

--- a/fw-child/single-resource.php
+++ b/fw-child/single-resource.php
@@ -1,7 +1,6 @@
 <?php
 	
 	if (
-		!is_user_logged_in() &&
 		get_field ( 'asset_type' ) == 'interactive' &&
 		get_field ( 'asset_post_' . $GLOBALS['fw']['current_lang_code'] ) != ''
 	) {


### PR DESCRIPTION
## Description

Context: Were unable to use Motion.page on Interactive posts because of the builder.

Changes:
- WP native styles mades available to posts of type interactive.
- Posts of type interactive are made public on requests that include the parameter motionpage_iframe=true. This parameter is used by Motion.page plugin when it calls the post for editing the animations.
- New page template for single posts of type interactive to skip the builder.
- Removed the condition of not being logged in, in order to see the content of a interactive post inside a resource post.

## Related ticket

Ticket [#66259 Conflict between Motion and the Builder](https://3.basecamp.com/3451303/buckets/37454340/todos/7544388004) 


> Make sure to read the *Pull requests process* in CONTRIBUTING.md.
> 
> Main points:
> 
> * The assigned reviewer(s) must always *submit* a review (not simply add a
>   comment).
>
> * If the PR is "Approved", the creator of the PR must then:
>   * Implement the changes in the reviewer's comments, if applicable, and mark
>     them as "Resolved".
>   * Squash and merge the branch.
>   * Delete the branch.
> 
> * If the PR is "Request Changes", the creator of the PR must then:
>   * Update the code as requested.
>   * Re-request a review from the reviewer.
>   * NOT mark the comments as "Resolved", the reviewer will.

