### PR TITLE
CLIM-707: Fix Builder breaking page when deleting spacing rows

### DIFF
--- a/framework/resources/js/builder.js
+++ b/framework/resources/js/builder.js
@@ -1247,15 +1247,19 @@
 		/**
 		 * Remove, from a list fields, empty variation settings.
 		 *
-		 * Some settings are made only of a list of variations. When they have no variation, the setting is essentially
-		 * empty. This function removes those.
+		 * Some settings are made only of a list of variations. When they have
+		 * no variation, the setting is essentially empty. This function removes
+		 * those.
 		 *
-		 * @param {{name: String, value: String}[]} fields List of form fields containing setting fields.
-		 * @return {{name: String, value: String}[]} The list of form fields without the empty variation settings.
+		 * @param {{name: String, value: String}[]} fields List of form fields
+		 *     containing setting fields.
+		 * @return {{name: String, value: String}[]} The list of form fields
+		 *     without the empty variation settings.
 		 */
-		filter_empty_variation_settings: function (fields) {
-			// The function makes two passes over the list of fields. A single pass would have been possible, but it would
-			// have made the code more complex, for no significant gain in performance.
+		filter_empty_variation_settings: function ( fields ) {
+			// The function makes two passes over the list of fields. A single
+			// pass would have been possible, but it would have made the code
+			// more complex, for no significant gain in performance.
 
 			////
 			// For each setting, save if it has rows defined.
@@ -1263,44 +1267,47 @@
 
 			const setting_has_variations = {};
 
-			fields.forEach(function (field) {
-				const name_parts = field.name.split('-');
+			fields.forEach( function ( field ) {
+				const name_parts = field.name.split( '-' );
 
-				if (name_parts.length < 4 || name_parts[1] !== 'settings[]') {
+				if ( name_parts.length < 4 || name_parts[ 1 ] !== 'settings[]' ) {
 					return;
 				}
 
-				const setting_name = name_parts[2];
+				const setting_name = name_parts[ 2 ];
 
-				if (!(setting_name in setting_has_variations)) {
-					setting_has_variations[setting_name] = false;
+				if ( ! ( setting_name in setting_has_variations ) ) {
+					setting_has_variations[ setting_name ] = false;
 				}
 
-				if (!setting_has_variations[setting_name] && name_parts[3] === 'rows[]') {
-					setting_has_variations[setting_name] = true;
+				if ( ! setting_has_variations[ setting_name ] && name_parts[ 3 ] === 'rows[]' ) {
+					setting_has_variations[ setting_name ] = true;
 				}
-			});
+			} );
 
 			////
 			// Filter out fields missing their required rows.
 			////
 
-			const settings_requiring_variations = ['spacing', 'attributes'];
+			const settings_requiring_variations = [ 'spacing', 'attributes' ];
 			const filtered_form_data = [];
 
-			fields.forEach(function (field) {
-				const name_parts = field.name.split('-');
+			fields.forEach( function ( field ) {
+				const name_parts = field.name.split( '-' );
 
-				if (name_parts.length >= 3 && name_parts[1] === 'settings[]') {
-					const setting_name = name_parts[2];
+				if ( name_parts.length >= 3 && name_parts[ 1 ] === 'settings[]' ) {
+					const setting_name = name_parts[ 2 ];
 
-					if (settings_requiring_variations.includes(setting_name) && !setting_has_variations[setting_name]) {
+					if (
+						settings_requiring_variations.includes( setting_name ) &&
+						! setting_has_variations[ setting_name ]
+					) {
 						return;
 					}
 				}
 
-				filtered_form_data.push(field);
-			});
+				filtered_form_data.push( field );
+			} );
 
 			return filtered_form_data;
 		},

--- a/framework/resources/js/builder.js
+++ b/framework/resources/js/builder.js
@@ -936,6 +936,8 @@
 					}
 					
 				})
+
+				form_data = plugin.filter_empty_variation_settings(form_data);
 				
 				// console.log(form_data)
 				
@@ -1240,6 +1242,67 @@
 				
 			})
 			
+		},
+
+		/**
+		 * Remove, from a list fields, empty variation settings.
+		 *
+		 * Some settings are made only of a list of variations. When they have no variation, the setting is essentially
+		 * empty. This function removes those.
+		 *
+		 * @param {{name: String, value: String}[]} fields List of form fields containing setting fields.
+		 * @return {{name: String, value: String}[]} The list of form fields without the empty variation settings.
+		 */
+		filter_empty_variation_settings: function (fields) {
+			// The function makes two passes over the list of fields. A single pass would have been possible, but it would
+			// have made the code more complex, for no significant gain in performance.
+
+			////
+			// For each setting, save if it has rows defined.
+			////
+
+			const setting_has_variations = {};
+
+			fields.forEach(function (field) {
+				const name_parts = field.name.split('-');
+
+				if (name_parts.length < 4 || name_parts[1] !== 'settings[]') {
+					return;
+				}
+
+				const setting_name = name_parts[2];
+
+				if (!(setting_name in setting_has_variations)) {
+					setting_has_variations[setting_name] = false;
+				}
+
+				if (!setting_has_variations[setting_name] && name_parts[3] === 'rows[]') {
+					setting_has_variations[setting_name] = true;
+				}
+			});
+
+			////
+			// Filter out fields missing their required rows.
+			////
+
+			const settings_requiring_variations = ['spacing', 'attributes'];
+			const filtered_form_data = [];
+
+			fields.forEach(function (field) {
+				const name_parts = field.name.split('-');
+
+				if (name_parts.length >= 3 && name_parts[1] === 'settings[]') {
+					const setting_name = name_parts[2];
+
+					if (settings_requiring_variations.includes(setting_name) && !setting_has_variations[setting_name]) {
+						return;
+					}
+				}
+
+				filtered_form_data.push(field);
+			});
+
+			return filtered_form_data;
 		},
 		
 		toggle_conditionals: function(this_input) {
@@ -1550,7 +1613,7 @@
 								// let new_html = $(loop_data.replaceAll(source_ID, options.globals.current_query.ID))
 								
 								// find first non-autogen element
-								let new_html = $(loop_data).find('.fw-element:not(.fw-page):not(.fw-auto-generated').first().prop('outerHTML') + $(loop_data).find('.fw-element:not(.fw-page):not(.fw-auto-generated').first().nextAll().prop('outerHTML')
+								let new_html = $(loop_data).find('.fw-element:not(.fw-page):not(.fw-auto-generated)').first().prop('outerHTML') + $(loop_data).find('.fw-element:not(.fw-page):not(.fw-auto-generated)').first().nextAll().prop('outerHTML')
 								
 								// console.log('new_html')
 								// console.log(new_html)


### PR DESCRIPTION
## Context

The Builder has a bug. When editing a block's settings, if we have a "Spacing" setting without any rows, and save the page, the page can no longer be rendered correctly.

To reproduce the bug:

* Connect to the WordPress admin
* “View” an already created page that can be edited with the Builder (ex: a News article)
* On any content (ex: a section, a container, a block, ...), click “Edit”
* Open the “Settings” tab
* If no “spacing” setting is already there:
  * Add a new “spacing” setting
  * Add some rows of spacing values
  * Save the field, save the page and reload
  * Re-open the settings tab of the content.
* For each spacing row, click the “Delete” button to delete the row, but don’t click the “X” to delete the “spacing” setting.
* Save the field, save the page and reload

Expected:
* The whole page shows up again, allowing to continue editing.

Actual:
* The page reloads, but only the blocks up to the block we edited above show up. All the following blocks don’t show up.
* Also, it’s not possible to edit the existing blocks.

## This PR

This PR solves the problem by removing the "Spacing" setting, when saving the block, if it doesn't contain any row.

When saving a block's settings, the JavaScript checks for "variation" settings, settings that are only made of a list of variations -- like "Spacing", and removes them if they don't have any variation (i.e. row).

**Also:**
* An unrelated but small fix is applied to line 1616, where 2 parenthesis were missing.

## Related ticket

https://ccdpwiki.atlassian.net/browse/CLIM-707
