### PR TITLE
CLIM-704: Hide the CookieYes banner when exporting a map image.

### DIFF
--- a/climate-data-ca/functions.php
+++ b/climate-data-ca/functions.php
@@ -209,8 +209,14 @@ add_action('wp_head',
      *
      * The inserted script tag requires an ID in the `cookieyes_id_<lang>` entry in the global 'vars' array. If the
      * entry is not defined or empty, no script tag is inserted.
+     *
+     * The script tag is not inserted if the HTTP GET parameter "nocookieyes" is present (no matter its value).
      */
     function () {
+        if ( isset( $_GET['nocookieyes'] ) ) {
+            return;
+        }
+
         $lang = $GLOBALS['vars']['current_lang'];
         $id_key = 'cookieyes_id_' . $lang;
         $cookieyes_id = $GLOBALS['vars'][$id_key] ?? '';

--- a/climate-data-ca/resources/js/variable-functions.js
+++ b/climate-data-ca/resources/js/variable-functions.js
@@ -2355,7 +2355,8 @@
                 } else {
                     // console.log('----- ' + history_action + ' -----');
                 }
-                $('#screenshot').attr('href', data_url + '/raster?url=' + encodeURL(new_url, url_encoder_salt).encoded);
+                const screenshot_url = new_url + '&nocookieyes=yes';
+                $('#screenshot').attr('href', data_url + '/raster?url=' + encodeURL(screenshot_url, url_encoder_salt).encoded);
             }
             history_action = 'push';
         }
@@ -3321,7 +3322,9 @@
         });
 
         // initially update screenshot button link
-        $('#screenshot').attr('href', data_url + '/raster?url=' + encodeURL(window.location.href, url_encoder_salt).encoded);
+        const url_has_params = window.location.href.indexOf('?') !== -1;
+        const screenshot_url = window.location.href + ( url_has_params ? '&' : '?') + 'nocookieyes=yes';
+        $('#screenshot').attr('href', data_url + '/raster?url=' + encodeURL(screenshot_url, url_encoder_salt).encoded);
 
         $.fn.prepare_raster = function(){
           $('#main-header').remove();


### PR DESCRIPTION
## Context

On version 1 of the site, the introduction of the CookieYes banner had an unwanted effect: when exporting a map as a PNG image, the CookieYes banner would show up in the image.

To reproduce:
* Open the map page (ex: https://climatedata.ca/variable/r20mm/)
* In the bottom right corner, click on "Export Map Image"
* Open the generated image

Expected:
* The image shows only the map

Actual
* The image shows the map, but also the CookieYes banner

## This PR

This PR gives the possibility to not include the CookieYes script tag (and thus not show the banner) by passing the `nocookieyes` parameter in the URL. The "Export Maps Image" button was updated to include this parameter before sending the request to the API server (which is responsible for taking the screenshot).

## Related ticket

https://ccdpwiki.atlassian.net/browse/CLIM-704