### PR TITLE
CLIM-715: Fix: Builder strips page content when too many elements

### DIFF
--- a/framework/resources/js/builder.js
+++ b/framework/resources/js/builder.js
@@ -1550,7 +1550,7 @@
 								// let new_html = $(loop_data.replaceAll(source_ID, options.globals.current_query.ID))
 								
 								// find first non-autogen element
-								let new_html = $(loop_data).find('.fw-element:not(.fw-page):not(.fw-auto-generated').first().prop('outerHTML') + $(loop_data).find('.fw-element:not(.fw-page):not(.fw-auto-generated').first().nextAll().prop('outerHTML')
+								let new_html = $(loop_data).find('.fw-element:not(.fw-page):not(.fw-auto-generated)').first().prop('outerHTML') + $(loop_data).find('.fw-element:not(.fw-page):not(.fw-auto-generated)').first().nextAll().prop('outerHTML')
 								
 								// console.log('new_html')
 								// console.log(new_html)
@@ -4871,8 +4871,7 @@
 					action: 'fw_update_post',
 					globals: options.globals,
 					post_id: options.post_id,
-					builder: options.page,
-					builder_string: JSON.stringify(options.page)
+					builder: JSON.stringify(options.page),
 				},
 				success: function(data) {
 					console.log(data)


### PR DESCRIPTION
## Context

There is a bug in the Builder. When saving a page that contains more than a certain number of elements (ex: sections, blocks, ...), the Builder "deletes" the last sections/elements, including the footer.

To reproduce:
* Create a new page, or edit an existing one.
* In the WordPress _Edit screen_ of the page, input the content of [this JSON file](https://github.com/user-attachments/files/16442880/builder.json) into the "Builder object" field.
* Save the page.
* "View" the page in the Builder.
* Without modifying anything, save the page using the Builder.
* Refresh the page.

Expected:
* The same content is shown, including the last sections and the footer.

Actual:
* The last sections of the page, including the footer were partly or completly removed.

## Reason of the bug

When saving the page, the Builder's JavaScript creates a POST request containing all the elements and their attributes. The POST request contains one parameter for each attribute of each element. When we have more than a certain number of elements, the number of parameters in the request can easily be over 1,000. For security reasons, PHP has a limit on the number of allowed parameters in a POST request. When it exceeds this number, PHP will simply strip the exceeding ones. The Builder's PHP code will thus receive only a limited list of elements and their attributes.

## This PR

This PR fixes the bug by changing how the the elements and their attributes are sent in the request. Instead of one parameter for each attribute, a single parameter is sent: the Builder object (containing the structure of the page) _stringified_ as a JSON object. The PHP then decodes this JSON object.

Also contains a small unrelated fix about missing parentheses.

## Related ticket

https://ccdpwiki.atlassian.net/browse/CLIM-715