### PR TITLE
CLIM-712: Fix: Apps are always shown only in English only

### DIFF
--- a/fw-child/acf-json/group_65efa3288aca3.json
+++ b/fw-child/acf-json/group_65efa3288aca3.json
@@ -203,11 +203,11 @@
             "endpoint": 0
         },
         {
-            "key": "field_65efa3289ea89",
-            "label": "App URL",
-            "name": "app_url",
+            "key": "field_66aa4a82d078b",
+            "label": "English",
+            "name": "",
             "aria-label": "",
-            "type": "text",
+            "type": "tab",
             "instructions": "",
             "required": 0,
             "conditional_logic": 0,
@@ -216,17 +216,85 @@
                 "class": "",
                 "id": ""
             },
-            "show_column_filter": false,
-            "allow_bulkedit": 0,
-            "allow_quickedit": 0,
-            "show_column": 0,
-            "show_column_weight": 1000,
-            "show_column_sortable": false,
+            "placement": "top",
+            "endpoint": 0,
+            "selected": 0
+        },
+        {
+            "key": "field_65efa3289ea89",
+            "label": "App URL",
+            "name": "app_url",
+            "aria-label": "",
+            "type": "text",
+            "instructions": "URL of the embedded app",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
             "default_value": "",
             "maxlength": "",
             "placeholder": "",
             "prepend": "",
             "append": ""
+        },
+        {
+            "key": "field_66aa4ab6d078c",
+            "label": "French",
+            "name": "",
+            "aria-label": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "top",
+            "endpoint": 0,
+            "selected": 0
+        },
+        {
+            "key": "field_66aa4ac5d078d",
+            "label": "App URL",
+            "name": "app_url_fr",
+            "aria-label": "",
+            "type": "text",
+            "instructions": "URL of the embedded app",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "maxlength": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": ""
+        },
+        {
+            "key": "field_66aa4c091293f",
+            "label": "",
+            "name": "",
+            "aria-label": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "top",
+            "endpoint": 1,
+            "selected": 0
         },
         {
             "key": "field_65efada5ce141",
@@ -242,12 +310,6 @@
                 "class": "",
                 "id": ""
             },
-            "show_column_filter": false,
-            "allow_bulkedit": 0,
-            "allow_quickedit": 0,
-            "show_column": 0,
-            "show_column_weight": 1000,
-            "show_column_sortable": false,
             "default_value": 0,
             "min": "",
             "max": "",
@@ -255,6 +317,24 @@
             "step": "",
             "prepend": "",
             "append": ""
+        },
+        {
+            "key": "field_66aa567d2298a",
+            "label": "English",
+            "name": "",
+            "aria-label": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "top",
+            "endpoint": 1,
+            "selected": 0
         },
         {
             "key": "field_65efae3ece142",
@@ -281,6 +361,44 @@
             "rows": 4,
             "placeholder": "",
             "new_lines": ""
+        },
+        {
+            "key": "field_66aa56962298c",
+            "label": "French",
+            "name": "",
+            "aria-label": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "top",
+            "endpoint": 0,
+            "selected": 0
+        },
+        {
+            "key": "field_66aa568e2298b",
+            "label": "Timeout message",
+            "name": "timeout_message_fr",
+            "aria-label": "",
+            "type": "textarea",
+            "instructions": "Message to display in case of a loading error",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "50",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "maxlength": "",
+            "rows": 4,
+            "placeholder": "",
+            "new_lines": ""
         }
     ],
     "location": [
@@ -301,5 +419,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1721667384
+    "modified": 1722439596
 }

--- a/fw-child/template/apps/embed.php
+++ b/fw-child/template/apps/embed.php
@@ -6,12 +6,12 @@
 	
 	
 		<iframe
-			data-src="<?php echo get_field ( 'app_url' ); ?>"
+			data-src="<?php echo fw_get_field ( 'app_url' ); ?>"
 			id="i_frame"
 			title="iframe"
 			allow="fullscreen"
-			data-timeout="<?php echo get_field ( 'timeout_timer' ); ?>"
-			data-timeout-message="<?php echo htmlspecialchars ( get_field ( 'timeout_message' ) ); ?>"
+			data-timeout="<?php echo get_field ( 'timeout' ); ?>"
+			data-timeout-message="<?php echo htmlspecialchars ( fw_get_field ( 'timeout_message' ) ); ?>"
 		></iframe>
 	
 


### PR DESCRIPTION
## Context

The v2 website doesn't allow a different URL for French for the embedded apps.

To reproduce:
* Visit the apps page in French (ex: https://donneesclimatiques2.crim.ca/apps/).
* Click on an app.

Expected:
* The app is shown in French.

Actual:
* The app is shown in English.

## This PR

This PR fixes the problem by adding an ACF field in the App post editor allowing to specify a French version of the URL. The code to embed the app was updated accordingly.

## Related ticket

https://ccdpwiki.atlassian.net/browse/CLIM-712