### PR TITLE
refs #63094: Make child pages visible. Show

### DIFF
--- a/fw-child/template/learn/query.php
+++ b/fw-child/template/learn/query.php
@@ -34,26 +34,25 @@
 					'orderby'        => 'date',
 					'order'          => 'desc',
 					'post_status'    => 'publish',
-					'post_parent'    => 0, // Only parent posts.
 					'tax_query'      => array(
 						array(
 							'taxonomy' => 'topic',
 							'field'    => 'slug',
-							'terms'    => array( $topic_term->slug )
-						)
+							'terms'    => array( $topic_term->slug ),
+						),
 					),
-					'meta_query'     => array(
+					'meta_query'    => array(
 						array(
-							'key'     => 'display_in_learning_zone',
-							'value'   => '1',
-						)
+							'key'   => 'display_in_learning_zone',
+							'value' => '1',
+						),
 					),
 				);
 				?>
 
 				<div id="topic-<?php echo esc_attr( $topic_term->term_id ); ?>"
-					 class="learn-topic-grid py-7"
-					 data-args='<?php echo json_encode( $posts_args ); ?>'>
+					class="learn-topic-grid py-7"
+					data-args='<?php echo json_encode( $posts_args ); ?>'>
 					<h4 class="learn-topic-title mb-5">
 						<?php
 						echo fw_get_field( 'title', 'topic_' . $topic_term->term_id );
@@ -62,7 +61,7 @@
 
 					<div class="query-container ">
 						<div class="fw-query-items row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3 g-lg-6"
-							 data-options='<?php echo json_encode( $item_options ); ?>'>
+							data-options='<?php echo json_encode( $item_options ); ?>'>
 							<div class="fw-query-item"></div>
 						</div>
 					</div>
@@ -73,7 +72,7 @@
 			?>
 
 			<div class="fw-query-items-no-matches py-7" style="display: none;">
-				<p class="alert alert-warning"><?php _e ( 'No items found.', 'cdc' ); ?></p>
+				<p class="alert alert-warning"><?php _e( 'No items found.', 'cdc' ); ?></p>
 			</div>
 		</div>
 	</div>

--- a/fw-child/template/query/learn-item.php
+++ b/fw-child/template/query/learn-item.php
@@ -16,14 +16,9 @@ $excerpts = array (
 
 <div class="card card--learn">
 
-	<?php
-	if ( has_post_thumbnail( $item['id'] ) ) { ?>
-		<div class="bg-dark">
-			<div class="card-img item-thumb" style="background-image: url(<?php echo get_the_post_thumbnail_url( $item['id'], 'medium_large' ); ?>);"></div>
-		</div>
-		<?php
-	}
-	?>
+	<div class="bg-dark">
+		<div class="card-img item-thumb" <?php echo has_post_thumbnail( $item['id'] ) ? 'style="background-image: url(' . get_the_post_thumbnail_url( $item['id'], 'medium_large' ) . ');"' : '' ?>></div>
+	</div>
 
 	<div class="card-body d-flex flex-column">
 		<h5 class="card-title item-title">

--- a/fw-child/template/query/learn-item.php
+++ b/fw-child/template/query/learn-item.php
@@ -16,7 +16,7 @@ $excerpts = array (
 
 <div class="card card--learn">
 
-	<div class="bg-dark">
+	<div class="bg-gray-400">
 		<div class="card-img item-thumb" <?php echo has_post_thumbnail( $item['id'] ) ? 'style="background-image: url(' . get_the_post_thumbnail_url( $item['id'], 'medium_large' ) . ');"' : '' ?>></div>
 	</div>
 


### PR DESCRIPTION
## Description

Removes the parents only parameter to be able to show partner's page. This criteria is no longer useful since the display in Learning Zone is now controlled by a custom toggle. Also, show an empty block when no post thumbnail is set to accommodate for a more uniform card design.

## Related ticket

[#67094 - Learning Zone](https://3.basecamp.com/3451303/buckets/37454340/todos/7379297436)


> Make sure to read the *Pull requests process* in CONTRIBUTING.md.
> 
> Main points:
> 
> * The assigned reviewer(s) must always *submit* a review (not simply add a
>   comment).
>
> * If the PR is "Approved", the creator of the PR must then:
>   * Implement the changes in the reviewer's comments, if applicable, and mark
>     them as "Resolved".
>   * Squash and merge the branch.
>   * Delete the branch.
> 
> * If the PR is "Request Changes", the creator of the PR must then:
>   * Update the code as requested.
>   * Re-request a review from the reviewer.
>   * NOT mark the comments as "Resolved", the reviewer will.
> 
> (You can keep or remove this block, as you wish.)
