### PR TITLE
refs #68214: remove linkedin news

### DIFF
--- a/fw-child/functions.php
+++ b/fw-child/functions.php
@@ -429,8 +429,6 @@ add_action( 'wp_footer', function() {
 
 <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js"></script>
 
-<script src="https://platform.linkedin.com/in.js" type="text/javascript">lang: en_US</script>
-
 <?php
 
 	}

--- a/fw-child/functions.php
+++ b/fw-child/functions.php
@@ -429,7 +429,7 @@ add_action( 'wp_footer', function() {
 
 <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js"></script>
 
-<script src="https://platform.linkedin.com/in.js" type="text/javascript">lang: en_US</script>]
+<script src="https://platform.linkedin.com/in.js" type="text/javascript">lang: en_US</script>
 
 <?php
 

--- a/fw-child/functions.php
+++ b/fw-child/functions.php
@@ -429,8 +429,7 @@ add_action( 'wp_footer', function() {
 
 <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js"></script>
 
-<script src="https://platform.linkedin.com/in.js" type="text/javascript">lang: en_US</script>
-<script type="IN/Share" data-url="https://www.linkedin.com"></script>
+<script src="https://platform.linkedin.com/in.js" type="text/javascript">lang: en_US</script>]
 
 <?php
 
@@ -599,10 +598,10 @@ function cdc_enable_block_editor( $use_block_editor, $post_type ) {
 
 /**
  * Updates the `interactive` post type arguments to make it public if loaded by the motion.page editor.
- * 
+ *
  * @param array   $args Array of arguments for registering a post type.
  * @param string  $post_type Post type key.
- * 
+ *
  * @return array  Array of arguments for registering a post type.
  */
 function cdc_make_interactive_cpt_public_for_motion_page( $args, $post_type ) {
@@ -617,7 +616,7 @@ function cdc_make_interactive_cpt_public_for_motion_page( $args, $post_type ) {
 }
 
 /**
- * Adjusts the current user and permissions if loaded by the Motion.page editor, 
+ * Adjusts the current user and permissions if loaded by the Motion.page editor,
  * making the page appear as if the user is not logged in.
  *
  * @return void

--- a/fw-child/functions.php
+++ b/fw-child/functions.php
@@ -421,8 +421,6 @@ add_action ( 'wp_head', function() {
 
 add_action( 'wp_footer', function() {
 
-	// FB/linkedin share scripts
-
 	if ( is_singular ( 'post' ) ) {
 
 ?>


### PR DESCRIPTION
## Description

Removing script on function.php that was displaying a unnecessary LinkedIn Share button.

## Related ticket

- https://rm.ewdev.ca/issues/68214

> Make sure to read the *Pull requests process* in CONTRIBUTING.md.
> 
> Main points:
> 
> * The assigned reviewer(s) must always *submit* a review (not simply add a
>   comment).
>
> * If the PR is "Approved", the creator of the PR must then:
>   * Implement the changes in the reviewer's comments, if applicable, and mark
>     them as "Resolved".
>   * Squash and merge the branch.
>   * Delete the branch.
> 
> * If the PR is "Request Changes", the creator of the PR must then:
>   * Update the code as requested.
>   * Re-request a review from the reviewer.
>   * NOT mark the comments as "Resolved", the reviewer will.
> 
> (You can keep or remove this block, as you wish.)
