### PR TITLE
CLIM-732: "Social links" Builder block: add option to use brand color…

### DIFF
--- a/fw-child/resources/functions/builder/field-groups/block/content/social-links.php
+++ b/fw-child/resources/functions/builder/field-groups/block/content/social-links.php
@@ -85,6 +85,11 @@ $lang = $_GET[ 'globals' ][ 'current_lang_code' ];
 				<label class="form-check-label" for="inputs-show_name">Show network names</label>
 			</div>
 
+			<div class="form-check form-check-inline">
+				<input class="form-check-input" type="checkbox" value="true" name="inputs-brand_colored" id="inputs-brand_colored">
+				<label class="form-check-label" for="inputs-brand_colored">Use brand colors</label>
+			</div>
+
 		</div>
 	</div>
 </div>

--- a/fw-child/resources/functions/builder/front-end/block/content/social-links.php
+++ b/fw-child/resources/functions/builder/front-end/block/content/social-links.php
@@ -84,7 +84,9 @@ if ( isset( $element[ 'inputs' ][ 'links' ][ 'rows' ] ) ) {
 						target="_blank"
 						rel="noopener"
 						title="<?php echo esc_attr( $link[ 'label' ] ) ?>"
-						style="<?php echo ( ! empty( $link[ 'brand-color' ] ) ) ? "color: {$link[ 'brand-color' ]};" : "" ?>"
+						<?php if ( ! empty( $link[ 'brand-color' ] ) ) : ?>
+							style="color: <?php echo $link[ 'brand-color' ] ?>;"
+						<?php endif; ?>
 					>
 						<i class="fa-brands <?php echo $link[ 'icon' ] ?>"></i>
 						<?php if ( $show_network_names ) : ?>

--- a/fw-child/resources/functions/builder/front-end/block/content/social-links.php
+++ b/fw-child/resources/functions/builder/front-end/block/content/social-links.php
@@ -13,30 +13,37 @@ $networks = [
 	'linkedin' => [
 		'icon' => 'fa-linkedin',
 		'name' => 'LinkedIn',
+		'brand-color' => '#0a66c2',
 	],
 	'x-twitter' => [
 		'icon' => 'fa-x-twitter',
 		'name' => 'X',
+		'brand-color' => '#000000',
 	],
 	'facebook' => [
 		'icon' => 'fa-facebook',
 		'name' => 'Facebook',
+		'brand-color' => '#1877f2',
 	],
 	'instagram' => [
 		'icon' => 'fa-instagram',
 		'name' => 'Instagram',
+		'brand-color' => '#c13584',
 	],
 	'soundcloud' => [
 		'icon' => 'fa-soundcloud',
 		'name' => 'SoundCloud',
+		'brand-color' => '#ff5500',
 	],
 ];
 
 $links = [];
 $show_network_names = $element[ 'inputs' ][ 'show_name' ] ?? false;
-// The builder may save the value as the string "true" or the boolean `true`,
+$use_brand_colors = $element[ 'inputs' ][ 'brand_colored' ] ?? false;
+// The builder may save checkbox values as the string "true" or the boolean `true`,
 // so we normalize.
 $show_network_names = ( true === $show_network_names || "true" === $show_network_names );
+$use_brand_colors = ( true === $use_brand_colors || "true" === $use_brand_colors );
 
 if ( isset( $element[ 'inputs' ][ 'links' ][ 'rows' ] ) ) {
 
@@ -51,17 +58,23 @@ if ( isset( $element[ 'inputs' ][ 'links' ][ 'rows' ] ) ) {
 
 		$network = $networks[ $row[ 'network' ] ];
 
-		$links[] = [
+		$link_data = [
 			'url' => $row[ 'url' ][ $lang ],
 			'icon' => $network[ 'icon' ],
 			'label' => $network[ 'name' ],
 		];
+
+		if ( $use_brand_colors ) {
+			$link_data[ 'brand-color' ] = $network[ 'brand-color' ];
+		}
+
+		$links[] = $link_data;
 	}
 }
 
 ?>
 
-<div class="social-networks">
+<div class="social-networks <?php echo $use_brand_colors ? 'brand-colored' : '' ?>">
 	<?php if ( ! empty( $links ) ) : ?>
 		<ul>
 			<?php foreach ( $links as $link ) : ?>
@@ -71,6 +84,7 @@ if ( isset( $element[ 'inputs' ][ 'links' ][ 'rows' ] ) ) {
 						target="_blank"
 						rel="noopener"
 						title="<?php echo esc_attr( $link[ 'label' ] ) ?>"
+						style="<?php echo ( ! empty( $link[ 'brand-color' ] ) ) ? "color: {$link[ 'brand-color' ]};" : "" ?>"
 					>
 						<i class="fa-brands <?php echo $link[ 'icon' ] ?>"></i>
 						<?php if ( $show_network_names ) : ?>

--- a/fw-child/resources/scss/_template.scss
+++ b/fw-child/resources/scss/_template.scss
@@ -446,10 +446,10 @@
   &.brand-colored {
     a {
       transition: opacity 0.1s;
-    }
-
-    a:hover {
-      opacity: 0.6;
+      
+      &:hover {
+        opacity: 0.6;
+      }
     }
   }
 }

--- a/fw-child/resources/scss/_template.scss
+++ b/fw-child/resources/scss/_template.scss
@@ -442,4 +442,14 @@
       margin-left: .20em;
     }
   }
+
+  &.brand-colored {
+    a {
+      transition: opacity 0.1s;
+    }
+
+    a:hover {
+      opacity: 0.6;
+    }
+  }
 }


### PR DESCRIPTION
## Context

A Builder block was recently created that allows to insert social links in a page. The links are shown as logos and their color is simply the default link color of where the block is inserted. So if the block is inserted in a page where links are red, we would see all the social icons red.

![image](https://github.com/user-attachments/assets/dc42cb24-9195-4994-829f-d694927d5abd)

This can be desired in some places, but in other places, we may want to show the icons as using their "brand" color (blue for Facebook, black for "X", etc.)

## This PR

This PR adds a checkbox in the edit form of the "Social links" block allowing to show the icons with their "brand" color instead of the default link color.

![image](https://github.com/user-attachments/assets/0ca8bb68-8129-4ce8-bf85-c29511c32379)


## Related ticket

https://ccdpwiki.atlassian.net/browse/CLIM-732