### PR TITLE
refs #67670: Translatable menu labels.

### DIFF
--- a/framework/functions.php
+++ b/framework/functions.php
@@ -289,7 +289,6 @@ function fw_menu_output( $menu, $level, $type, $classes ) {
 
 		if (
 			( ! empty( $ancestors ) && in_array( $post_id, $ancestors ) ) ||
-
 			( isset( $GLOBALS['vars']['current_ancestors'] ) && in_array( $item['id'], $GLOBALS['vars']['current_ancestors'] ) )
 		) {
 			echo 'ancestor-nav-item ';
@@ -320,7 +319,7 @@ function fw_menu_output( $menu, $level, $type, $classes ) {
 
 		echo '">';
 
-		if ( isset( $item['icon'] ) && ! empty( $item['icon'] ) ) {
+		if ( ! empty( $item['icon'] ) ) {
 			echo '<i class="icon ' . esc_attr( $item['icon'] ) . ' mr-3"></i>';
 		}
 

--- a/framework/functions.php
+++ b/framework/functions.php
@@ -240,19 +240,25 @@ function fw_build_menu ( array &$elements, $parent_id = 0, $level = 1 ) {
 
 }
 
-function fw_menu_output ( $menu, $level, $type, $classes ) {
+/**
+ * Outputs the menu HTML.
+ *
+ * @param array  $menu The menu items.
+ * @param int    $level The menu level.
+ * @param string $type The menu type.
+ * @param array  $classes The CSS classes.
+ */
+function fw_menu_output( $menu, $level, $type, $classes ) {
 
 	$element_class = $classes['menu'];
-	$item_class = $classes['item'];
-	$link_class = $classes['link'];
-	
-	// global $element_class;
-	// global $item_class;
-	// global $link_class;
+	$item_class    = $classes['item'];
+	$link_class    = $classes['link'];
 
-	echo '<ul class="fw-menu-' . $type . ' menu-level-' . $level . ' ';
+	echo '<ul class="fw-menu-' . esc_attr( $type ) . ' menu-level-' . esc_attr( $level ) . ' ';
 
-	if ( $level == 1 ) echo $element_class;
+	if ( 1 === $level ) {
+		echo esc_attr( $element_class );
+	}
 
 	echo '">';
 
@@ -264,74 +270,87 @@ function fw_menu_output ( $menu, $level, $type, $classes ) {
 		if ( isset( $GLOBALS['vars']['current_url'] ) ) {
 			$current_host = parse_url( $GLOBALS['vars']['current_url'], PHP_URL_HOST );
 			$current_path = parse_url( $GLOBALS['vars']['current_url'], PHP_URL_PATH );
-			$current_url = $current_host . $current_path;
+			$current_url  = $current_host . $current_path;
 
 			$item_host = parse_url( $item['url'], PHP_URL_HOST );
 			$item_path = parse_url( $item['url'], PHP_URL_PATH );
-			$item_url =  $item_host . $item_path;
+			$item_url  = $item_host . $item_path;
 
-			if ( $current_url == $item_url ) {
+			if ( $current_url === $item_url ) {
 				$is_item_of_current_page = true;
 				echo 'current-nav-item ';
 			}
 		}
 
 		// If the item's page is an ancestor of the current page
-		// or if the item is an ancestor of the current menu item ID
-		$post_id = get_post_meta( $item['id'], '_menu_item_object_id', true );
+		// or if the item is an ancestor of the current menu item ID.
+		$post_id   = get_post_meta( $item['id'], '_menu_item_object_id', true );
 		$ancestors = get_post_ancestors( get_the_ID() );
 
-		if ( 
-			! empty( $ancestors ) &&
-			in_array( $post_id, $ancestors ) ||
+		if (
+			( ! empty( $ancestors ) && in_array( $post_id, $ancestors ) ) ||
 
-			isset( $GLOBALS['vars']['current_ancestors'] ) &&
-			in_array( $item['id'], $GLOBALS['vars']['current_ancestors'] )
+			( isset( $GLOBALS['vars']['current_ancestors'] ) && in_array( $item['id'], $GLOBALS['vars']['current_ancestors'] ) )
 		) {
 			echo 'ancestor-nav-item ';
 		}
 
-		// other classes
-		echo $item_class;
+		// other classes.
+		echo esc_attr( $item_class );
 
 		echo '">';
 
-			echo '<a href="' . $item['url'] . '"';
+		echo '<a href="' . esc_url( $item['url'] ) . '"';
 
-			if ( isset ( $item['target'] ) && $item['target'] == 'blank' ) {
-				echo ' target="_blank"';
-			}
+		if ( isset( $item['target'] ) && 'blank' === $item['target'] ) {
+			echo ' target="_blank"';
+		}
 
-			echo ' class="';
+		echo ' class="';
 
-			if ( $is_item_of_current_page ) {
-				echo 'current-nav-link ';
-			}
-			
-			if ( isset ( $item['classes'] ) && is_array ( $item['classes'] ) ) echo ' ' . implode ( ' ', $item['classes'] );
-			
-			echo ' ' . $link_class;
-			
-			echo '">';
+		if ( $is_item_of_current_page ) {
+			echo 'current-nav-link ';
+		}
 
-			if ( isset ( $item['icon'] ) && $item['icon'] != '' ) {
-				echo '<i class="icon ' . $item['icon'] . ' mr-3"></i>';
-			}
+		if ( isset( $item['classes'] ) && is_array( $item['classes'] ) ) {
+			echo ' ' . esc_attr( implode( ' ', $item['classes'] ) );
+		}
 
-			echo $item['title'] . '</a>';
+		echo ' ' . esc_attr( $link_class );
 
-			if ( isset ( $item['children'] ) ) {
+		echo '">';
 
-				fw_menu_output ( $item['children'], $level + 1, $type, $classes );
+		if ( isset( $item['icon'] ) && ! empty( $item['icon'] ) ) {
+			echo '<i class="icon ' . esc_attr( $item['icon'] ) . ' mr-3"></i>';
+		}
 
-			}
+		// Get the translation of the item label.
+		$item_label_translation = get_post_meta( $item['id'] )[ 'label_' . $GLOBALS['fw']['current_lang_code'] ];
+
+		// If the current language is not English and the translation is not empty, use the translation.
+		if ( 'en' !== $GLOBALS['fw']['current_lang_code'] && ! empty( $item_label_translation[0] ) ) {
+
+			$item_title = $item_label_translation[0];
+
+		} else {
+
+			$item_title = $item['title'];
+
+		}
+
+		echo esc_html( $item_title ) . '</a>';
+
+		if ( isset( $item['children'] ) ) {
+
+			fw_menu_output( $item['children'], $level + 1, $type, $classes );
+
+		}
 
 		echo '</li>';
 
 	}
 
 	echo '</ul>';
-
 }
 
 add_action ( 'fw_global_css', function() { } );

--- a/fw-child/acf-json/group_66df020542d03.json
+++ b/fw-child/acf-json/group_66df020542d03.json
@@ -4,11 +4,11 @@
     "fields": [
         {
             "key": "field_66df02086184d",
-            "label": "Label FR",
+            "label": "Custom Label for French",
             "name": "label_fr",
             "aria-label": "",
             "type": "text",
-            "instructions": "",
+            "instructions": "Custom menu label to use in French. Leave empty to use the page's name.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {

--- a/fw-child/acf-json/group_66df020542d03.json
+++ b/fw-child/acf-json/group_66df020542d03.json
@@ -1,0 +1,45 @@
+{
+    "key": "group_66df020542d03",
+    "title": "Menu items",
+    "fields": [
+        {
+            "key": "field_66df02086184d",
+            "label": "Label FR",
+            "name": "label_fr",
+            "aria-label": "",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "maxlength": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "nav_menu_item",
+                "operator": "==",
+                "value": "all"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_rest": 0,
+    "modified": 1725891164
+}


### PR DESCRIPTION
## Description

Problem: Unable to translate a custom label for the menu items in Wordpress.
This PR solves this by adding a custom 'label_fr' field in the menu items and using it for FR language if it is filled.

- From the CMS, go to **Appearance**, **Menus**.
- Select a menu for testing. Ex: Primary Navigation.
- In the menu items drop downs, you should see a new field called **Label FR**.
- If you customize the Navigation Label, it will change the menu label in both languages instead of using the page's title as the label.
- If you fill the **Label FR** fields, it should use it in the FR version of the menu.

## Related ticket

[67670 Rendre les libellés de menus traduisible](https://3.basecamp.com/3451303/buckets/37454340/todos/7636520875)


> Make sure to read the *Pull requests process* in CONTRIBUTING.md.
> 
> Main points:
> 
> * The assigned reviewer(s) must always *submit* a review (not simply add a
>   comment).
>
> * If the PR is "Approved", the creator of the PR must then:
>   * Implement the changes in the reviewer's comments, if applicable, and mark
>     them as "Resolved".
>   * Squash and merge the branch.
>   * Delete the branch.
> 
> * If the PR is "Request Changes", the creator of the PR must then:
>   * Update the code as requested.
>   * Re-request a review from the reviewer.
>   * NOT mark the comments as "Resolved", the reviewer will.
> 
> (You can keep or remove this block, as you wish.)
