### PR TITLE
Fixed warnings when launching the dev version with `WP_WP_DEBUG=true`

### DIFF
--- a/framework/functions.php
+++ b/framework/functions.php
@@ -324,7 +324,7 @@ function fw_menu_output( $menu, $level, $type, $classes ) {
 		}
 
 		// Get the translation of the item label.
-		$item_label_translation = get_post_meta( $item['id'] )[ 'label_' . $GLOBALS['fw']['current_lang_code'] ];
+		$item_label_translation = get_post_meta( $item['id'] )[ 'label_' . $GLOBALS['fw']['current_lang_code'] ] ?? '';
 
 		// If the current language is not English and the translation is not empty, use the translation.
 		if ( 'en' !== $GLOBALS['fw']['current_lang_code'] && ! empty( $item_label_translation[0] ) ) {

--- a/framework/resources/functions/builder/builder.php
+++ b/framework/resources/functions/builder/builder.php
@@ -381,7 +381,7 @@ function fw_setup_element ( $element, $globals ) {
 	// data-* attributes array
 	
 	$settings['atts'] = array (
-		'key' => $element['key']
+		'key' => $element['key'] ?? null
 	);
 	
 	switch ( $settings['el_type'] ) {
@@ -487,7 +487,7 @@ function fw_setup_element ( $element, $globals ) {
 	
 	// classes
 	
-	$settings['el_id'] = 'element-' . $element['key'];
+	$settings['el_id'] = 'element-' . ($element['key'] ?? '');
 	
 	if (
 		isset ( $element['inputs']['id'] ) && 

--- a/framework/resources/functions/builder/front-end/block/data/field.php
+++ b/framework/resources/functions/builder/front-end/block/data/field.php
@@ -31,9 +31,9 @@
 			echo '<' . $element['inputs']['display'] . '>';
 		}
 
-		echo $element['inputs']['prepend'];
+		echo $element['inputs']['prepend'] ?? '';
 		echo $field_output;
-		echo $element['inputs']['append'];
+		echo $element['inputs']['append'] ?? '';
 		
 		if ( $element['inputs']['display'] != 'none' ) {
 			echo '</' . $element['inputs']['display'] . '>';

--- a/framework/resources/functions/builder/front-end/block/navigation/menu.php
+++ b/framework/resources/functions/builder/front-end/block/navigation/menu.php
@@ -4,7 +4,7 @@ $menu = array();
 
 // 1. CREATE MENU ITEMS
 
-if ( str_contains ( $element['inputs']['menu'], 'menu-' ) ) {
+if ( str_contains ( $element['inputs']['menu'] ?? '', 'menu-' ) ) {
 	
 	// WP MENU
 	


### PR DESCRIPTION
## Description

Added a few verifications of null values in `functions.php`, `builder.php`, `field.php` and `menu.php` to make the website not show a warning when a key has no value assigned and the `WP_WP_DEBUG` option is set to `True`.

> Make sure to read the *Pull requests process* in CONTRIBUTING.md.
> 
> Main points:
> 
> * The assigned reviewer(s) must always *submit* a review (not simply add a
>   comment).
>
> * If the PR is "Approved", the creator of the PR must then:
>   * Implement the changes in the reviewer's comments, if applicable, and mark
>     them as "Resolved".
>   * Squash and merge the branch.
>   * Delete the branch.
> 
> * If the PR is "Request Changes", the creator of the PR must then:
>   * Update the code as requested.
>   * Re-request a review from the reviewer.
>   * NOT mark the comments as "Resolved", the reviewer will.
> 
> (You can keep or remove this block, as you wish.)
