### PR TITLE
CLIM-748: fix: Builder corrupts JSONcorruption

### DIFF
--- a/framework/resources/js/builder.js
+++ b/framework/resources/js/builder.js
@@ -287,8 +287,8 @@
 				
 				// if inserting/editing a block,
 				// also set category and content properties
-				
-				if (options.modal.content.includes('/')) {
+
+				if (options.status !== 'editing' && options.modal.content.includes('/')) {
 					options.element.data.type = options.modal.content
 				}
 				

--- a/framework/resources/js/builder.js
+++ b/framework/resources/js/builder.js
@@ -2330,7 +2330,7 @@
 			
 			$.ajax({
 				url: ajax_data.url,
-				type: 'GET',
+				type: 'POST',
 				data: {
 					action: 'fw_setup_element_ajax',
 					globals: options.globals,


### PR DESCRIPTION
Bug: When editing the content of a page using the Builder, the "type" of some blocks sometimes changes to another type, making the block content and its type incompatible. See the description of CLIM-748 for a way to reproduce the bug.

Bug: When saving a text block with a content exceedding around 4000 characters, a request error is triggered, preventing from create the content of the text block.

This PR provides a fix for those bugs.