### PR TITLE
EW-73147: Re-add GitHub Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Description
+
+(Replace this paragraph with a description of changes introduced by your pull
+request. If applicable, don't hesitate to include context for the changes,
+description of incorrect behaviour fixed, reasons for a new feature, etc.)
+
+## Related ticket
+
+(If a ticket in your task manager is linked to this PR, replace this paragraph
+with the URL to the ticket. If not applicable, you can remove this whole
+section.)
+
+
+> Make sure to read the *Pull requests process* in CONTRIBUTING.md.
+>
+> Main points:
+>
+> * The assigned reviewer(s) must always *submit* a review (not simply add a
+    >   comment).
+>
+> * If the PR is "Approved", the creator of the PR must then:
+    >   * Implement the changes in the reviewer's comments, if applicable, and mark
+          >     them as "Resolved".
+>   * Squash and merge the branch.
+>   * Delete the branch.
+>
+> * If the PR is "Request Changes", the creator of the PR must then:
+    >   * Update the code as requested.
+>   * Re-request a review from the reviewer.
+>   * NOT mark the comments as "Resolved", the reviewer will.
+>
+> (You can keep or remove this block, as you wish.)


### PR DESCRIPTION
Re-add previous GitHub Pull Request template from previous commits. Below is @xfrenette-crim comment for more context:

> The reason is because GitHub requires that the .github directory be in the main branch. We effectively did it in the past. But when we implemented the new Git development process we changed the name of some branches, including main. So the .github directory is now in another branch !