### PR TITLE
CLIM-850: Fix: menu items not translated in the header 

### DIFF
--- a/framework/functions.php
+++ b/framework/functions.php
@@ -327,7 +327,7 @@ function fw_menu_output( $menu, $level, $type, $classes ) {
 		$item_label_translation = get_post_meta( $item['id'] )[ 'label_' . $GLOBALS['fw']['current_lang_code'] ] ?? '';
 
 		// If the current language is not English and the translation is not empty, use the translation.
-		if ( 'en' !== $GLOBALS['fw']['current_lang_code'] && ! is_array( $item_label_translation ) && ! empty( $item_label_translation[0] ) ) {
+		if ( 'en' !== $GLOBALS['fw']['current_lang_code'] && is_array( $item_label_translation ) && ! empty( $item_label_translation[0] ) ) {
 
 			$item_title = $item_label_translation[0];
 


### PR DESCRIPTION
Menu Item titles wouldn't be translated if they were an array, but they're always an array (once they are updated in WP Admin.)

Related ticket : CLIM-850