### PR TITLE
CLIM-867: Fix: The learning zone page keeps slowly scrolling

### DIFF
--- a/climate-data-ca/resources/scss/child.scss
+++ b/climate-data-ca/resources/scss/child.scss
@@ -215,12 +215,6 @@ h1, h2, h3, h4, h5, h6,
 body {
   &.has-alert {
     #header-primary {
-      background-color: transparentize($black, 0.7);
-
-      @include media-breakpoint-down(lg) {
-        background-color: transparentize($black, 0.2);
-      }
-
       .logo {
         a {
           top: calc(-50% - 15px);
@@ -244,16 +238,9 @@ body {
       }
     }
 
-    &.header-stuck {
-      #header-primary {
-        background-color: transparentize($black, 0.3);
-      }
-    }
-
     &.alert-closing,
     &.alert-closed {
       #header-primary {
-        background-color: transparentize($black, 0.3);
 
         .logo {
           a {

--- a/climate-data-ca/resources/scss/pages/_training.scss
+++ b/climate-data-ca/resources/scss/pages/_training.scss
@@ -3,6 +3,13 @@
 //
 
 #training-filter {
+  // (Following line) Fix: The learning zone page keeps slowly scrolling (only
+  //   in Chrome) when the filters bar is "sticky".
+  //   Ref: CLIM-867
+  @include media-breakpoint-up(sm) {
+    height: 59px;
+  }
+
   &.is_stuck {
     z-index: 10;
   }

--- a/climate-data-ca/tpl-training.php
+++ b/climate-data-ca/tpl-training.php
@@ -44,11 +44,11 @@
     <nav id="training-filter" class="navbar navbar-expand navbar-light bg-light">
       
       <ul class="navbar-nav tabs-nav w-100 flex-column flex-sm-row align-items-center justify-content-center">
-        <li class="nav-item"><span class="nav-link disabled p-4 all-caps"><?php _e ( 'Filter:', 'cdc' ); ?></a></li>
-        <li class="nav-item"><span class="nav-link p-4 all-caps" data-type="video"><?php _e ( 'Video', 'cdc' ); ?></a></li>
-        <li class="nav-item"><span class="nav-link p-4 all-caps" data-type="audio"><?php _e ( 'Audio', 'cdc' ); ?></a></li>
-        <li class="nav-item"><span class="nav-link p-4 all-caps" data-type="interactive"><?php _e ( 'Interactive', 'cdc' ); ?></a></li>
-        <li class="nav-item"><span class="nav-link p-4 all-caps" data-type="article"><?php _e ( 'Article', 'cdc' ); ?></a></li>
+        <li class="nav-item"><span class="nav-link disabled p-4 all-caps"><?php _e ( 'Filter:', 'cdc' ); ?></span></li>
+        <li class="nav-item"><span class="nav-link p-4 all-caps" data-type="video"><?php _e ( 'Video', 'cdc' ); ?></span></li>
+        <li class="nav-item"><span class="nav-link p-4 all-caps" data-type="audio"><?php _e ( 'Audio', 'cdc' ); ?></span></li>
+        <li class="nav-item"><span class="nav-link p-4 all-caps" data-type="interactive"><?php _e ( 'Interactive', 'cdc' ); ?></span></li>
+        <li class="nav-item"><span class="nav-link p-4 all-caps" data-type="article"><?php _e ( 'Article', 'cdc' ); ?></span></li>
       </ul>
       
     </nav>

--- a/h7-parent/header.php
+++ b/h7-parent/header.php
@@ -140,32 +140,28 @@ if (current_user_can('administrator')) {
     // CHECK FOR ALERTS
     //
 
-    if (is_front_page()) {
+	$alert_query = new WP_Query (array('post_type' => 'post', 'posts_per_page' => 1, 'meta_query' => array('relation' => 'AND', array('key' => 'post_alert', 'value' => 1), array('key' => 'post_alert-start', 'value' => $GLOBALS['vars']['date'], 'compare' => '<'), array('key' => 'post_alert-end', 'value' => $GLOBALS['vars']['date'], 'compare' => '>'))));
 
-        $alert_query = new WP_Query (array('post_type' => 'post', 'posts_per_page' => 1, 'meta_query' => array('relation' => 'AND', array('key' => 'post_alert', 'value' => 1), array('key' => 'post_alert-start', 'value' => $GLOBALS['vars']['date'], 'compare' => '<'), array('key' => 'post_alert-end', 'value' => $GLOBALS['vars']['date'], 'compare' => '>'))));
+	if ($alert_query->have_posts()) :
 
-        if ($alert_query->have_posts()) :
+		$body_class[] = 'has-alert';
 
-            $body_class[] = 'has-alert';
+		while ($alert_query->have_posts()) : $alert_query->the_post();
 
-            while ($alert_query->have_posts()) : $alert_query->the_post();
+			$alert = array('title' => get_the_title(), 'permalink' => get_permalink());
 
-                $alert = array('title' => get_the_title(), 'permalink' => get_permalink());
+		endwhile;
 
-            endwhile;
+	endif;
 
-        endif;
+	wp_reset_postdata();
 
-        wp_reset_postdata();
+	//
 
-    }
-
-		//
-
-		// $body_class = do_action ( 'example_action', $body_class );
+	// $body_class = do_action ( 'example_action', $body_class );
 
 
-		$body_class = apply_filters ( 'custom_body_classes', $body_class );
+	$body_class = apply_filters ( 'custom_body_classes', $body_class );
 
     ?>
 


### PR DESCRIPTION
## Bug description

In the learning zone page, when we start scrolling (enough so that the "filters" bar gets "sticky" to the top bar), the page keeps slowly scrolling upward. The bug happened only in Chrome.

## This PR

This PR introduces a fix to the bug. The bug is caused by the "Sticky Kit" jQuery plugin. The bug is fixed by fixing the height of the filters bar to a integer value.

## Related ticket

CLIM-867