### PR TITLE
refs #77333: Selection of cells in download app map

### DIFF
--- a/apps/src/components/download/step-summary.tsx
+++ b/apps/src/components/download/step-summary.tsx
@@ -44,8 +44,8 @@ const StepSummary: React.FC = () => {
 			content: _n(
 				'1 cell selected',
 				'%d cells selected',
-				selectedCells
-			).replace('%d', String(selectedCells)),
+				selectedCells.length
+			).replace('%d', String(selectedCells.length)),
 		},
 		{
 			title: __('Additional details'),

--- a/apps/src/components/map-layers/selectable-cells-grid-layer.tsx
+++ b/apps/src/components/map-layers/selectable-cells-grid-layer.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useRef } from 'react';
+import { useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet.vectorgrid';
+
+import { useDownload } from '@/hooks/use-download';
+import { useAppSelector } from '@/app/hooks';
+import { DEFAULT_MAX_ZOOM } from '@/lib/constants';
+
+/**
+ * Mouse over event handler logic:
+ * map.js line 843
+ *
+ * Grid layer for gridded_data sector:
+ * cdc.js line 623
+ */
+const SelectableCellsGridLayer: React.FC<{
+	selectedCells: Set<number>;
+	onSelectCell: (updatedCells: Set<number>) => void;
+}> = ({ selectedCells, onSelectCell }) => {
+	const map = useMap();
+
+	const { setField } = useDownload();
+
+	// @ts-expect-error: suppress leaflet typescript error
+	const gridLayerRef = useRef<L.VectorGrid | null>(null);
+
+	const {
+		variable,
+		dataset,
+		decade,
+		frequency,
+		interactiveRegion,
+		emissionScenario,
+	} = useAppSelector((state) => state.map);
+
+	useEffect(() => {
+		// TODO: this should not be a static value, because it needs to work also in other environments other than prod
+		const geoserverUrl = '//dataclimatedata.crim.ca';
+
+		const gridName = 'canadagrid';
+
+		const selectedCellStyles = {
+			fill: true,
+			fillColor: '#fff',
+			fillOpacity: 0.2,
+		};
+
+		// keep track of the map's zoom and center in case we get back to this step
+		const handleMoveEnd = () => {
+			setField('zoom', map.getZoom());
+			setField('center', [map.getCenter().lat, map.getCenter().lng]);
+		};
+
+		map.on('zoomend', handleMoveEnd);
+		map.on('moveend', handleMoveEnd);
+
+		const handleClick = async (e: {
+			latlng: L.LatLng;
+			layer: { properties: { gid: number } };
+		}) => {
+			const { gid } = e.layer.properties;
+
+			// create a new Set from the current selected cells to avoid mutating the state
+			const newSelectedCells = new Set(selectedCells);
+
+			if (newSelectedCells.has(gid)) {
+				newSelectedCells.delete(gid);
+				gridLayerRef.current?.resetFeatureStyle(gid);
+			} else {
+				newSelectedCells.add(gid);
+				gridLayerRef.current?.setFeatureStyle(gid, selectedCellStyles);
+			}
+
+			//cCall onSelectCell with the updated Set
+			onSelectCell(newSelectedCells);
+		};
+
+		const tileLayerUrl = `${geoserverUrl}/geoserver/gwc/service/tms/1.0.0/CDC:${gridName}@EPSG%3A900913@pbf/{z}/{x}/{-y}.pbf`;
+
+		// @ts-expect-error: suppress leaflet typescript error
+		const gridLayer = L.vectorGrid.protobuf(tileLayerUrl, {
+			interactive: true,
+			maxNativeZoom: DEFAULT_MAX_ZOOM,
+			getFeatureId: (feature: { properties: { gid: number } }) =>
+				feature.properties.gid,
+			vectorTileLayerStyles: {
+				[gridName]: function () {
+					return {
+						weight: 0.1,
+						color: '#fff',
+						opacity: 1,
+						fill: true,
+						radius: 4,
+						fillOpacity: 0,
+					};
+				},
+			},
+			bounds: L.latLngBounds(
+				L.latLng(41, -141.1), // _southWest
+				L.latLng(83.6, -49.9) // _northEast
+			),
+			maxZoom: DEFAULT_MAX_ZOOM,
+			minZoom: 7, // not using DEFAULT_MIN_ZOOM because then the cells would appear before zooming in and it slows the map rendering
+			pane: 'grid', // TODO: figure out how `pane` works in the map
+		});
+
+		gridLayerRef.current = gridLayer;
+
+		gridLayer.on('click', handleClick);
+
+		gridLayer.addTo(map);
+
+		// apply styles to already selected cells when the grid loads
+		selectedCells.forEach((gid) => {
+			gridLayer.setFeatureStyle(gid, selectedCellStyles);
+		});
+
+		return () => {
+			map.removeLayer(gridLayer);
+		};
+	}, [
+		map,
+		interactiveRegion,
+		frequency,
+		dataset,
+		variable,
+		decade,
+		emissionScenario,
+		selectedCells,
+		setField,
+		onSelectCell,
+	]);
+
+	return null;
+};
+
+export default SelectableCellsGridLayer;

--- a/apps/src/context/download-provider.tsx
+++ b/apps/src/context/download-provider.tsx
@@ -91,8 +91,8 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({
 				return isValidEmail(String(value));
 			}
 
-			// a zero is valid for number types, except in step 4 where selectedCells are required
-			if (typeof value === 'number' && key !== 'selectedCells') {
+			// a zero is valid for number types
+			if (typeof value === 'number') {
 				return true;
 			}
 

--- a/apps/src/features/download/download-slice.ts
+++ b/apps/src/features/download/download-slice.ts
@@ -7,6 +7,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 import { DownloadState } from '@/types/types';
+import { CANADA_CENTER, DEFAULT_ZOOM } from '@/lib/constants';
 
 // Define the initial state this slice is going to use.
 export const initialState: DownloadState = {
@@ -19,7 +20,9 @@ export const initialState: DownloadState = {
 	endYear: 2030,
 	frequency: 'Annual',
 	emissionScenarios: [],
-	selectedCells: 1, // temporarily set to 1 so that the step can be submitted
+	selectedCells: [],
+	zoom: DEFAULT_ZOOM,
+	center: CANADA_CENTER,
 	percentiles: [],
 	decimalPlace: 2,
 	format: 'csv',

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -4,7 +4,7 @@ import { VariantProps } from 'class-variance-authority';
 import { buttonVariants } from '@/lib/format';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { LucideIcon } from 'lucide-react';
-import L from 'leaflet';
+import L, { LatLngExpression } from 'leaflet';
 
 /**
  * Represents valid locale values.
@@ -174,7 +174,9 @@ export interface DownloadState {
 	endYear: number;
 	frequency: string;
 	emissionScenarios: string[];
-	selectedCells: number;
+	selectedCells: number[];
+	zoom: number;
+	center: LatLngExpression;
 	percentiles: string[];
 	decimalPlace: number;
 	format: string;


### PR DESCRIPTION
## Description

This PR implements selecting cells in the download app location step, when Grid Cells is selected. It will also update the "Selected cells" value and it will persist both selected cells value, selected cells in map, map zoom and map center in case the user goes back to the location step from the Summary card.

## Related ticket

