### PR TITLE
#79666: Add datasets and variables lists endpoint

### DIFF
--- a/fw-child/acf-json/group_677ff329db550.json
+++ b/fw-child/acf-json/group_677ff329db550.json
@@ -77,6 +77,27 @@
             "selected": 0
         },
         {
+            "key": "field_67b7ad4a9038f",
+            "label": "Title",
+            "name": "title_fr",
+            "aria-label": "",
+            "type": "text",
+            "instructions": "The dataset term French title.",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "maxlength": "",
+            "allow_in_bindings": 0,
+            "placeholder": "",
+            "prepend": "",
+            "append": ""
+        },
+        {
             "key": "field_677ff44bc0007",
             "label": "Card Description",
             "name": "card_description_fr",
@@ -133,5 +154,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1736523124
+    "modified": 1740090740
 }

--- a/fw-child/resources/functions/rest-v3/datasets-list.php
+++ b/fw-child/resources/functions/rest-v3/datasets-list.php
@@ -97,7 +97,7 @@ function cdc_rest_v3_get_datasets_list( $request ) {
 			);
 
 			if ( ! empty( $card_descriptions ) ) {
-				$card['description'] = $card_description;
+				$card['description'] = $card_descriptions;
 			}
 
 			// Add card links if available.

--- a/fw-child/resources/functions/rest-v3/datasets-list.php
+++ b/fw-child/resources/functions/rest-v3/datasets-list.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Datasets list endpoint.
+ *
+ * This file defines the REST API endpoint for retrieving datasets list
+ * from the WordPress taxonomy 'variable-dataset'. It includes functions
+ * for handling pagination, data formatting, and cache control.
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register custom REST API endpoints for retrieving
+ * datasets list,
+ */
+register_rest_route(
+	'cdc/v3',
+	'datasets-list',
+	array(
+		'methods'             => WP_REST_Server::READABLE,
+		'callback'            => 'cdc_rest_v3_get_datasets_list',
+		'permission_callback' => 'cdc_rest_v3_endpoint_permission',
+		'args'                => cdc_rest_v3_get_datasets_args(),
+	)
+);
+
+/**
+ * Retrieve the datasets list for the REST API endpoint.
+ *
+ * This function handles the retrieval of dataset terms based on pagination parameters.
+ * It constructs the response with dataset details and includes pagination headers if applicable.
+ *
+ * @param WP_REST_Request $request The request object.
+ *
+ * @return WP_REST_Response|WP_Error The response object or WP_Error on failure.
+ */
+function cdc_rest_v3_get_datasets_list( $request ) {
+	try {
+		// Get pagination parameters.
+		$per_page = $request->get_param( 'per_page' );
+		$page     = $request->get_param( 'page' );
+
+		// Get all variable dataset terms.
+		$args = array(
+			'taxonomy'   => 'variable-dataset',
+			'hide_empty' => false,
+		);
+
+		// Only add 'number' and offset if not requesting all items.
+		if ( $per_page !== -1 ) {
+			$args['number'] = $per_page;
+			$args['offset'] = ( $page - 1 ) * $per_page;
+		}
+
+		$terms = get_terms( $args );
+
+		// Check if terms exist.
+		if ( is_wp_error( $terms ) ) {
+			return new WP_Error(
+				'no_terms_found',
+				esc_html__( 'No dataset terms found.', 'cdc' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$datasets = array();
+
+		foreach ( $terms as $term ) {
+			$term_id = absint( $term->term_id );
+
+			// Get ACF fields
+			$title_fr            = get_field( 'title_fr', 'term_' . $term_id );
+			$card_description    = get_field( 'card_description', 'term_' . $term_id );
+			$card_description_fr = get_field( 'card_description_fr', 'term_' . $term_id );
+			$card_link           = get_field( 'card_link', 'term_' . $term_id );
+			$card_link_fr        = get_field( 'card_link_fr', 'term_' . $term_id );
+
+			// Build dataset array.
+			$dataset = array(
+				'term_id' => $term_id,
+			);
+
+			// Add titles if available.
+			$titles = cdc_rest_v3_build_multilingual_field(
+				$term->name,
+				$title_fr
+			);
+			if ( ! empty( $titles ) ) {
+				$dataset['title'] = $titles;
+			}
+
+			// Build card object.
+			$card = array();
+
+			// Add card descriptions if available.
+			$card_descriptions = cdc_rest_v3_build_multilingual_field(
+				$card_description,
+				$card_description_fr
+			);
+			if ( ! empty( $card_descriptions ) ) {
+				$card['description'] = $card_description;
+			}
+
+			// Add card links if available.
+			$card_links = cdc_rest_v3_build_multilingual_field(
+				$card_link,
+				$card_link_fr
+			);
+			if ( ! empty( $card_links ) ) {
+				$card['link'] = $card_links;
+			}
+
+			// Add card object if it has content.
+			if ( ! empty( $card ) ) {
+				$dataset['card'] = $card;
+			}
+
+			$datasets[] = $dataset;
+		}
+
+		// Prepare the response.
+		$response = array(
+			'datasets' => $datasets,
+		);
+
+		// Add pagination headers only if not requesting all items.
+		if ( $per_page !== -1 ) {
+			$total_terms = wp_count_terms( array( 'taxonomy' => 'variable-dataset' ) );
+			if ( is_wp_error( $total_terms ) ) {
+				$total_terms = 0;
+			}
+			$total_pages = ceil( $total_terms / $per_page );
+
+			// Set headers for pagination.
+			$response_headers = array(
+				'X-WP-Total'      => $total_terms,
+				'X-WP-TotalPages' => $total_pages,
+			);
+
+			// Add headers to response.
+			$response_object = new WP_REST_Response( $response, 200 );
+			foreach ( $response_headers as $key => $value ) {
+				$response_object->header( $key, $value );
+			}
+		} else {
+			// Simple response without pagination headers when getting all items.
+			$response_object = new WP_REST_Response( $response, 200 );
+		}
+
+		return $response_object;
+
+	} catch ( Exception $e ) {
+		return new WP_Error(
+			'server_error',
+			esc_html__( 'An unexpected error occurred.', 'cdc' ),
+			array( 'status' => 500 )
+		);
+	}
+}
+
+/**
+ * Get the arguments for the datasets list REST API endpoint.
+ *
+ * This function returns an array of arguments for the datasets list
+ * endpoint, including pagination parameters. Each argument includes
+ * a description, type, default value, and a sanitize callback.
+ *
+ * @return array The arguments for the datasets list endpoint.
+ */
+function cdc_rest_v3_get_datasets_args() {
+	return array(
+		'per_page' => array(
+			'description'       => 'Number of items per page. Use -1 for all items.',
+			'type'              => 'integer',
+			'default'           => -1,
+			'minimum'           => -1,
+			'maximum'           => 100,
+			'sanitize_callback' => 'cdc_rest_v3_sanitize_arg_per_page',
+		),
+		'page'     => array(
+			'description'       => 'Current page number',
+			'type'              => 'integer',
+			'default'           => 1,
+			'minimum'           => 1,
+			'sanitize_callback' => 'absint',
+		),
+	);
+}
+
+/**
+ * Set cache headers for the datasets list REST API endpoint.
+ *
+ * This function sets the Cache-Control header to cache the response
+ * for 24 hours if the request is for the 'cdc/v3/datasets-list' endpoint.
+ *
+ * @param bool $served Whether the request has already been served.
+ * @param WP_HTTP_Response $result Result to send to the client.
+ * @param WP_REST_Request $request Request used to generate the response.
+ * @param WP_REST_Server $server Server instance.
+ *
+ * @return bool True if the request has been served, otherwise false.
+ */
+function cdc_rest_v3_set_cache( $served, $result, $request, $server ) {
+	if ( strpos( $request->get_route(), 'cdc/v3/datasets-list' ) !== false ) {
+		header( 'Cache-Control: public, max-age=86400' ); // Cache for 24 hours.
+	}
+
+	return $served;
+}
+
+add_action( 'rest_pre_serve_request', 'cdc_rest_v3_set_cache', 10, 4 );

--- a/fw-child/resources/functions/rest-v3/init.php
+++ b/fw-child/resources/functions/rest-v3/init.php
@@ -18,12 +18,13 @@ defined( 'ABSPATH' ) || exit;
 function cdc_rest_v3_init() {
 	// Load endpoint definitions.
 	require_once dirname( __FILE__ ) . '/datasets-list.php';
+	require_once dirname( __FILE__ ) . '/variables-list.php';
 }
 
 add_action( 'rest_api_init', 'cdc_rest_v3_init' );
 
 /**
- * Permission callback for V3 endpoints.
+ * Permission callback for REST API V3 endpoints.
  *
  * Ensures requests only come from the same WordPress domain.
  *

--- a/fw-child/resources/functions/rest-v3/init.php
+++ b/fw-child/resources/functions/rest-v3/init.php
@@ -148,3 +148,35 @@ function cdc_rest_v3_build_multilingual_field( $en, $fr ) {
 
 	return ! empty( $field ) ? $field : null;
 }
+
+/**
+ * Set cache headers for REST API V3 endpoints.
+ *
+ * This function sets the Cache-Control header to cache the response
+ * for 24 hours for specific REST API V3 endpoints.
+ *
+ * @param bool $served Whether the request has already been served.
+ * @param WP_HTTP_Response $result Result to send to the client.
+ * @param WP_REST_Request $request Request used to generate the response.
+ * @param WP_REST_Server $server Server instance.
+ *
+ * @return bool True if the request has been served, otherwise false.
+ */
+function cdc_rest_v3_set_cache( $served, $result, $request, $server ) {
+	$cacheable_endpoints = [
+		'cdc/v3/datasets-list',
+		'cdc/v3/variables-list',
+	];
+
+	$route = $request->get_route();
+
+	if ( array_filter( $cacheable_endpoints, function ( $endpoint ) use ( $route ) {
+		return strpos( $route, $endpoint ) !== false;
+	} ) ) {
+		header( 'Cache-Control: public, max-age=86400' ); // Cache for 24 hours.
+	}
+
+	return $served;
+}
+
+add_action( 'rest_pre_serve_request', 'cdc_rest_v3_set_cache', 10, 4 );

--- a/fw-child/resources/functions/rest-v3/init.php
+++ b/fw-child/resources/functions/rest-v3/init.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * REST API V3 initialization.
+ *
+ * This file initializes the WordPress REST API V3 functionality for
+ * map and download applications. It handles registration and loading
+ * of custom endpoints and defines common functions.
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register REST API V3 endpoints.
+ *
+ * @return void
+ */
+function cdc_rest_v3_init() {
+	// Load endpoint definitions.
+	require_once dirname( __FILE__ ) . '/datasets-list.php';
+}
+
+add_action( 'rest_api_init', 'cdc_rest_v3_init' );
+
+/**
+ * Permission callback for V3 endpoints.
+ *
+ * Ensures requests only come from the same WordPress domain.
+ *
+ * @return bool|WP_Error True if permission granted, WP_Error otherwise
+ */
+function cdc_rest_v3_endpoint_permission() {
+	// Get the WordPress site URL and domain.
+	$site_url = parse_url( get_site_url(), PHP_URL_HOST );
+
+	// Get HTTP referer.
+	$referer      = isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '';
+	$referer_host = $referer ? parse_url( $referer, PHP_URL_HOST ) : '';
+
+	// Get request origin.
+	$origin      = isset( $_SERVER['HTTP_ORIGIN'] ) ? $_SERVER['HTTP_ORIGIN'] : '';
+	$origin_host = $origin ? parse_url( $origin, PHP_URL_HOST ) : '';
+
+	// Check if request is from REST API interface.
+	$is_rest_request = defined( 'REST_REQUEST' ) && REST_REQUEST;
+
+	// Get the current request host.
+	$request_host = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : '';
+
+	// Security checks.
+	$is_same_domain = false;
+
+	// Clean and validate domains.
+	$site_url     = sanitize_text_field( $site_url );
+	$referer_host = sanitize_text_field( $referer_host );
+	$origin_host  = sanitize_text_field( $origin_host );
+	$request_host = sanitize_text_field( $request_host );
+
+	// Check if the request is from the same domain.
+	if ( $is_rest_request && ! empty( $request_host ) ) {
+		// Compare with site URL.
+		if ( $request_host === $site_url ) {
+			$is_same_domain = true;
+		}
+
+		// Check referer if available.
+		if ( ! empty( $referer_host ) && $referer_host === $site_url ) {
+			$is_same_domain = true;
+		}
+
+		// Check origin if available.
+		if ( ! empty( $origin_host ) && $origin_host === $site_url ) {
+			$is_same_domain = true;
+		}
+
+		// Allow local environment (useful when testing against production).
+		if ( WP_DEBUG && in_array( $request_host, [ 'dev-en.climatedata.ca', 'dev-fr.climatedata.ca' ] ) ) {
+			$is_same_domain = true;
+		}
+	}
+
+	// Log unauthorized attempts if logging is enabled.
+	if ( ! $is_same_domain && WP_DEBUG ) {
+		error_log( sprintf(
+			'Unauthorized API access attempt from: %s, Referer: %s, Origin: %s',
+			$request_host,
+			$referer_host,
+			$origin_host
+		) );
+	}
+
+	// Return result.
+	if ( $is_same_domain ) {
+		return true;
+	}
+
+	return new WP_Error(
+		'rest_forbidden',
+		esc_html__( 'Access denied. Only same-domain requests are allowed.', 'cdc' ),
+		array(
+			'status' => 403,
+			'source' => 'domain_restriction'
+		)
+	);
+}
+
+/**
+ * Sanitize the 'per_page' argument for REST API requests.
+ *
+ * @param int $value The 'per_page' argument to sanitize.
+ *
+ * @return int The sanitized 'per_page' value.
+ */
+function cdc_rest_v3_sanitize_arg_per_page( $value ) {
+	$value = intval( $value );
+
+	// Allow -1 for all items.
+	if ( $value === -1 ) {
+		return -1;
+	}
+
+	// Ensure value is between 1 and 100.
+	return max( 1, min( 100, $value ) );
+}
+
+/**
+ * Build a multilingual field array.
+ *
+ * This function creates an associative array with 'en' and 'fr' keys
+ * if the corresponding input values are not empty. If both inputs are empty,
+ * it returns null.
+ *
+ * @param string $en The English value of the field.
+ * @param string $fr The French value of the field.
+ *
+ * @return array|null The multilingual field array or null if both inputs are empty.
+ */
+function cdc_rest_v3_build_multilingual_field( $en, $fr ) {
+	$field = array();
+
+	if ( ! empty( $en ) ) {
+		$field['en'] = $en;
+	}
+
+	if ( ! empty( $fr ) ) {
+		$field['fr'] = $fr;
+	}
+
+	return ! empty( $field ) ? $field : null;
+}

--- a/fw-child/resources/functions/rest-v3/variables-list.php
+++ b/fw-child/resources/functions/rest-v3/variables-list.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Variables list endpoint.
+ *
+ * This file defines the REST API endpoint for retrieving variables list
+ * with associated metadata, taxonomies, and translations.
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Register custom REST API endpoints for retrieving
+ * variables list.
+ */
+register_rest_route(
+	'cdc/v3',
+	'variables-list',
+	array(
+		'methods'             => WP_REST_Server::READABLE,
+		'callback'            => 'cdc_rest_v3_get_variables_list',
+		'permission_callback' => 'cdc_rest_v3_endpoint_permission',
+		'args'                => cdc_rest_v3_get_variables_args(),
+	)
+);
+
+/**
+ * Retrieve the variables list for the REST API endpoint.
+ *
+ * @param WP_REST_Request $request The request object.
+ *
+ * @return WP_REST_Response|WP_Error The response object or WP_Error on failure.
+ */
+function cdc_rest_v3_get_variables_list( $request ) {
+	try {
+		// Get pagination parameters
+		$posts_per_page = $request->get_param( 'posts_per_page' );
+		$paged          = $request->get_param( 'paged' );
+
+		// Query arguments for variables
+		$args = array(
+			'post_type'   => 'variable',
+			'post_status' => 'publish',
+			'posts_per_page' => -1,
+		);
+
+		// Only add 'posts_per_page' and 'paged' if not requesting all items.
+		if ( $posts_per_page !== -1 ) {
+			$args['posts_per_page'] = $posts_per_page;
+			$args['paged']          = $paged;
+		}
+
+		$query     = new WP_Query( $args );
+		$variables = array();
+
+		foreach ( $query->posts as $post ) {
+			$post_id = $post->ID;
+
+			// Get taxonomies data.
+			$taxonomies = array(
+				'sector'            => cdc_rest_v3_get_taxonomy_terms_data( $post_id, 'sector' ),
+				'region'            => cdc_rest_v3_get_taxonomy_terms_data( $post_id, 'region' ),
+				'var-type'          => cdc_rest_v3_get_taxonomy_terms_data( $post_id, 'var-type' ),
+				'variable-datasets' => cdc_rest_v3_get_taxonomy_terms_data( $post_id, 'variable-dataset' ),
+			);
+
+			// Build variable array
+			$variable = array(
+				'id'      => get_field( 'var_id', $post_id ),
+				'post_id' => $post_id,
+				'meta'    => array(
+					'updated-on' => get_the_modified_date( 'Y-m-d H:i:s', $post_id ),
+					'content'    => array(
+						'title' => cdc_rest_v3_build_multilingual_field(
+							$post->post_title,
+							get_field( 'title_fr', $post_id )
+						),
+					),
+				),
+			);
+
+			// Get ACF fields
+			$card_description    = get_field( 'card_description', $post_id );
+			$card_description_fr = get_field( 'card_description_fr', $post_id );
+			$card_link           = get_field( 'card_link', $post_id );
+			$card_link_fr        = get_field( 'card_link_fr', $post_id );
+
+			// Build card object.
+			$card = array();
+
+			// Add card descriptions if available.
+			$card_descriptions = cdc_rest_v3_build_multilingual_field(
+				$card_description,
+				$card_description_fr
+			);
+
+			if ( ! empty( $card_descriptions ) ) {
+				$card['description'] = $card_descriptions;
+			}
+
+			// Add card links if available.
+			$card_links = cdc_rest_v3_build_multilingual_field(
+				$card_link,
+				$card_link_fr
+			);
+
+			if ( ! empty( $card_links ) ) {
+				$card['link'] = $card_links;
+			}
+
+			// Add card object if it has content.
+			if ( ! empty( $card ) ) {
+				$variable['meta']['content']['card'] = $card;
+			}
+
+			// Add thumbnail if available
+			$thumbnail_size = 'post-thumbnail';
+			$thumbnail      = get_the_post_thumbnail_url( $post_id, $thumbnail_size );
+
+			if ( ! empty( $thumbnail ) ) {
+				$variable['meta']['content']['thumbnail'] = $thumbnail;
+			}
+
+			// Add taxonomies if not empty
+			if ( ! empty( $taxonomies ) ) {
+				$variable['meta']['taxonomy'] = $taxonomies;
+			}
+
+			$variables[] = $variable;
+		}
+
+		// Prepare response
+		$response = array(
+			'variables' => $variables,
+		);
+
+		// Add pagination headers if not requesting all items
+		if ( $posts_per_page !== -1 ) {
+			$response_headers = array(
+				'X-WP-Total'      => $query->found_posts,
+				'X-WP-TotalPages' => $query->max_num_pages,
+			);
+
+			$response_object = new WP_REST_Response( $response, 200 );
+
+			foreach ( $response_headers as $key => $value ) {
+				$response_object->header( $key, $value );
+			}
+		} else {
+			$response_object = new WP_REST_Response( $response, 200 );
+		}
+
+		return $response_object;
+	} catch ( Exception $e ) {
+		return new WP_Error(
+			'server_error',
+			esc_html__( 'An unexpected error occurred.', 'cdc' ),
+			array( 'status' => 500 )
+		);
+	}
+}
+
+/**
+ * Helper function to get taxonomy terms data.
+ *
+ * @param int $post_id The post ID.
+ * @param string $taxonomy The taxonomy name.
+ *
+ * @return array The formatted taxonomy terms data.
+ */
+function cdc_rest_v3_get_taxonomy_terms_data( $post_id, $taxonomy ) {
+	$terms           = wp_get_post_terms( $post_id, $taxonomy );
+	$formatted_terms = array();
+
+	if ( ! is_wp_error( $terms ) ) {
+		foreach ( $terms as $term ) {
+			$formatted_terms[] = array(
+				'term_id' => $term->term_id,
+				'title'   => cdc_rest_v3_build_multilingual_field(
+					$term->name,
+					get_field( 'title_fr', $term )
+				),
+			);
+		}
+	}
+
+	return array( 'terms' => $formatted_terms );
+}
+
+/**
+ * Get the arguments for the datasets list REST API endpoint.
+ *
+ * This function returns an array of arguments for the variables list
+ * endpoint, including pagination parameters. Each argument includes
+ * a description, type, default value, and a sanitize callback.
+ *
+ * @return array The arguments for the datasets list endpoint.
+ */
+function cdc_rest_v3_get_variables_args() {
+	return array(
+		'posts_per_page' => array(
+			'description'       => 'Number of items per page. Use -1 for all items.',
+			'type'              => 'integer',
+			'default'           => -1,
+			'minimum'           => -1,
+			'maximum'           => 100,
+			'sanitize_callback' => 'cdc_rest_v3_sanitize_arg_per_page',
+		),
+		'paged'          => array(
+			'description'       => 'Current page number',
+			'type'              => 'integer',
+			'default'           => 1,
+			'minimum'           => 1,
+			'sanitize_callback' => 'absint',
+		),
+	);
+}

--- a/fw-child/resources/functions/rest.php
+++ b/fw-child/resources/functions/rest.php
@@ -16,16 +16,16 @@ register_meta ( 'post', 'title_fr', array (
 //
 
 add_action ( 'rest_api_init', function () {
-	
+
 	register_rest_route ( 'cdc/v2', '/get_default_var/', array (
-		'methods' => 'GET', 
-		'callback' => 'cdc_get_default_var' 
+		'methods' => 'GET',
+		'callback' => 'cdc_get_default_var'
 	) );
-	
+
 });
 
 function cdc_get_default_var () {
-	
+
 	$result = new WP_Query ( array (
 		'post_type' => 'variable',
 		'posts_per_page' => 1,
@@ -38,20 +38,20 @@ function cdc_get_default_var () {
 			)
 		)
 	) );
-	
+
 	if ( $result->have_posts() ) {
 		while ( $result->have_posts() ) {
 			$result->the_post();
-			
+
 			return get_the_ID();
-			
+
 		}
 	} else {
 		return '{}';
 	}
-	
+
 	// return $args;
-	
+
 }
 
 add_filter ( 'rest_variable_query', 'cdc_get_default_var', 10, 2 );
@@ -68,25 +68,25 @@ add_filter ( 'posts_where', 'wpza_replace_repeater_field' );
 //
 
 add_action ( 'rest_api_init', function () {
-	
+
 	register_rest_route ( 'cdc/v2', '/related/', array (
-		'methods' => 'GET', 
-		'callback' => 'cdc_get_related_content' 
+		'methods' => 'GET',
+		'callback' => 'cdc_get_related_content'
 	) );
-	
+
 });
 
 function cdc_get_related_content () {
-	
+
 	$result = array(
 		'sectors' => [],
 		'training' => []
 	);
 
 	// SECTORS
-	
+
 	$sectors = get_the_terms ( $_GET['var_id'], 'sector' );
-	
+
 	foreach ( $sectors as $sector ) {
 		$result['sectors'][] = array (
 			'id' => $sector->term_id,
@@ -94,10 +94,10 @@ function cdc_get_related_content () {
 			'url' => home_url ( '/learn/' ) . '?q=sector:' . $sector->slug
 		);
 	}
-	
+
 	// TRAINING
-	
-	$lz_query = get_posts ( array ( 
+
+	$lz_query = get_posts ( array (
 		'post_type' => 'resource',
 		'posts_per_page' => 3,
 		'post_parent' => 0,
@@ -111,7 +111,7 @@ function cdc_get_related_content () {
 			)
 		)
 	) );
-	
+
 	foreach ( $lz_query as $lz_post ) {
 		$result['training'][] = array (
 			'id' => $lz_post->ID,
@@ -119,9 +119,9 @@ function cdc_get_related_content () {
 			'url' => get_permalink ( $lz_post->ID )
 		);
 	}
-	
+
 	return $result;
-	
+
 }
 
 //
@@ -129,14 +129,14 @@ function cdc_get_related_content () {
 //
 
 function cdc_get_var ( $args, $request ) {
-	
+
 	if ( isset ( $request['var'] ) ) {
 		$args['meta_key'] = 'var_name';
 		$args['meta_value'] = $request['var'];
 	}
-	
+
 	return $args;
-	
+
 }
 
 add_filter ( 'rest_variable_query', 'cdc_get_var', 10, 2 );
@@ -146,54 +146,54 @@ add_filter ( 'rest_variable_query', 'cdc_get_var', 10, 2 );
 //
 
 add_action ( 'rest_api_init', function () {
-	
+
 	register_rest_route ( 'cdc/v2', '/finch_submit/', array (
-		'methods' => 'POST', 
-		'callback' => 'cdc_finch_submit' 
+		'methods' => 'POST',
+		'callback' => 'cdc_finch_submit'
 	) );
-	
+
 });
 
 function cdc_finch_submit () {
-	
+
 	include_once ( locate_template ( 'resources/php/securimage/securimage.php' ) );
 	include_once ( locate_template ( 'resources/php/mailchimp.php' ) );
-	
+
 	$securimage = new Securimage();
-	
+
 	if ( isset ( $_POST['namespace'] ) ) {
 		$securimage->setNamespace(sanitize_title_with_dashes($_POST['namespace']));
 	}
-	
+
 	$submit_url = $GLOBALS['vars']['pavics_url'] . $_POST['submit_url'];
 	$data_url = "https:" . $GLOBALS['vars']['data_url'];
-	
+
 	$result = '{ "status": "captcha failed" }';
-	
+
 	if ( isset ( $_POST['captcha_code'] ) ) {
-	
+
 		if ( $securimage->check( $_POST['captcha_code'] ) == true ) {
-			
+
 			// if the request was sent with required vars
 			if (
-				isset ( $_POST['required_variables'] ) && 
+				isset ( $_POST['required_variables'] ) &&
 				isset ( $_POST['stations'] )
 			) {
-				
+
 				$inputs = [];
-				
+
 				foreach ($_POST['required_variables'] as $variable) {
 					$type = strpos($variable, "tas") !== false ? 'T':'P';
 					$inputs[] = ['id' => $variable, 'href' => $data_url . "/download-ahccd?format=netcdf&variable_type_filter=$type&stations={$_POST['stations']}"];
 				}
-				
+
 				$_POST['request_data']['inputs'] = array_merge($_POST['request_data']['inputs'], $inputs);
-				
+
 			}
-			
+
 			// initialize cURL request
 			$request = curl_init ( $submit_url );
-			
+
 			// cURL options
 			curl_setopt ( $request, CURLOPT_CUSTOMREQUEST, 'POST' );
 			curl_setopt ( $request, CURLOPT_POSTFIELDS, str_replace ( "\\\\\\", "\\", json_encode ( $_POST['request_data'] ) ) );
@@ -203,14 +203,14 @@ function cdc_finch_submit () {
 			// exec
 			$result = curl_exec($request);
 			curl_close($request);
-			
+
 			if ( $_POST['signup'] == 'true' ) {
 				mailchimp_register ( $_POST['request_data']['notification_email'] );
 			}
-			
+
 		} // captcha check
 	} // captcha isset
-	
+
 	echo $result;
 
 }
@@ -225,9 +225,9 @@ add_filter ( 'acf/rest/format_value_for_rest/name=var_description_fr', 'cdc_form
 add_filter ( 'acf/rest/format_value_for_rest/name=var_tech_description_fr', 'cdc_format_wysiwyg_in_rest', 10, 5);
 
 function cdc_format_wysiwyg_in_rest ($value_formatted, $post_id, $field, $value, $format) {
-	
+
 	return do_shortcode ( apply_filters ( 'the_content', $value_formatted ) );
-	
+
 }
 
 
@@ -241,7 +241,7 @@ function cdc_var_types_field () {
 			'schema' => null,
 		)
 	);
-	
+
 }
 
 add_action ( 'rest_api_init', 'cdc_var_types_field' );
@@ -257,7 +257,7 @@ function cdc_list_var_types ( $object, $field_name, $request ) {
 	}
 
 	return $term_list;
-	
+
 }
 
 //
@@ -267,12 +267,12 @@ function cdc_list_var_types ( $object, $field_name, $request ) {
 // GET LOCATION BY ID
 
 add_action ( 'rest_api_init', function () {
-	
+
 	register_rest_route ( 'cdc/v2', '/get_location_by_id/', array (
-		'methods' => 'GET', 
-		'callback' => 'cdc_get_location_by_id' 
+		'methods' => 'GET',
+		'callback' => 'cdc_get_location_by_id'
 	) );
-	
+
 });
 
 function cdc_get_location_by_id () {
@@ -281,9 +281,9 @@ function cdc_get_location_by_id () {
 
 		// remove possible bad stuff
 		$loc = preg_replace ( "/[^a-zA-Z0-9]+/", "", $_GET['loc'] );
-		
+
 		$term_append = ( $GLOBALS['fw']['current_lang_code'] == 'fr' ) ? '_fr' : '';
-		
+
 		$columns = array (
 			"id_code as geo_id",
 			"geo_name",
@@ -295,25 +295,25 @@ function cdc_get_location_by_id () {
 		);
 
 		require_once locate_template ( 'resources/app/db.php' );
-		
+
 		$row = [];
-		
+
 		$main_query = mysqli_query ( $GLOBALS['vars']['con'], "SELECT " . implode ( ", ", $columns ) . " FROM all_areas WHERE id_code = '" . $loc . "'" ) or die ( mysqli_error ( $GLOBALS['vars']['con'] ) );
 
 		if ($main_query->num_rows > 0) {
 			$row = mysqli_fetch_assoc ( $main_query );
-	
+
 			$row['coords'] = [ floatval ( $row['lat'] ), floatval ( $row['lon'] ) ];
 			$row['lat'] = floatval ( $row['lat'] );
 			$row['lng'] = floatval ( $row['lon'] );
 			$row['province_short'] = short_province ( $row['province'] );
 			$row['title'] = $row['geo_name'] . ', ' . $row['province_short'];
 		}
-		
+
 		echo json_encode ( $row );
-	
+
 	} else {
-	
+
 		echo '[]';
 
 	}
@@ -323,23 +323,23 @@ function cdc_get_location_by_id () {
 // GET LOCATION BY COORDS
 
 add_action ( 'rest_api_init', function () {
-	
+
 	register_rest_route ( 'cdc/v2', '/get_location_by_coords/', array (
-		'methods' => 'GET', 
-		'callback' => 'cdc_get_location_by_coords' 
+		'methods' => 'GET',
+		'callback' => 'cdc_get_location_by_coords'
 	) );
-	
+
 });
 
 function cdc_get_location_by_coords () {
-	
+
 	if (
 		( isset ( $_GET['lat'] ) && !empty ( $_GET['lat'] ) ) &&
 		( isset ( $_GET['lng'] ) && !empty ( $_GET['lng'] ) )
 	) {
-		
+
 		if ( locate_template ( 'resources/app/db.php' ) == '' ) {
-			
+
 			echo json_encode ( array (
 				'lat' => $lat,
 				'lng' => $lng,
@@ -348,42 +348,42 @@ function cdc_get_location_by_coords () {
 				'geo_name' => __ ( 'Point', 'cdc' ),
 				'title' => __ ( 'Point', 'cdc' ) . ' (' . number_format ( $lat, 4, '.', '') . ', ' . number_format ( $lng, 4, '.', '') . ')'
 			) );
-			
+
 		} else {
-			
+
 			require_once locate_template ( 'resources/app/db.php' );
-			
+
 			$lat = floatval ( $_GET['lat'] );
 			$lng = floatval ( $_GET['lng'] );
-			
+
 			// add _fr if needed
 			$term_append = ( $GLOBALS['fw']['current_lang_code'] == 'fr' ) ? '_fr' : '';
-			
+
 			$columns = array (
-				"all_areas.id_code as geo_id", 
-				"geo_name", 
-				"gen_term" . $term_append . " as generic_term", 
-				"location", 
-				"province" . $term_append, 
-				"lat", 
+				"all_areas.id_code as geo_id",
+				"geo_name",
+				"gen_term" . $term_append . " as generic_term",
+				"location",
+				"province" . $term_append,
+				"lat",
 				"lon"
 			);
-			
+
 			// $columns = implode ( ",", $columns );
 			$join = "";
-			
+
 			if ( $_GET['sealevel'] == 'true' ) {
 				$join = "JOIN all_areas_sealevel ON (all_areas.id_code=all_areas_sealevel.id_code)";
 			}
-	
+
 			$ranges = [ 0.05, 0.1, 0.2 ];
 			$preferred_terms = [ 'Community', 'Metropolitan Area' ];
 			$found_community = false;
-			
+
 			// gradually increase the range until we find a community
-			
+
 			foreach ( $ranges as $range ) {
-				
+
 				if ( $found_community == false ) {
 					$main_query = mysqli_query($GLOBALS['vars']['con'], "SELECT " . implode(",", $columns) . "
 					, DISTANCE_BETWEEN($lat, $lng, lat,lon) as distance
@@ -394,54 +394,54 @@ function cdc_get_location_by_coords () {
 					AND gen_term NOT IN ('Railway Point', 'Railway Junction', 'Urban Community', 'Administrative Sector')
 					ORDER BY DISTANCE
 					LIMIT 50");// or die (mysqli_error($GLOBALS['vars']['con']));
-					
+
 					if ($main_query->num_rows > 0) {
-						
+
 						while ( $row = mysqli_fetch_assoc ( $main_query ) ) {
-							
+
 							if ( in_array ( $row['generic_term'], $preferred_terms ) ) {
 								$result = $row;
-								
+
 								// might be good to know
 								// what range is the community in from the click
 								$result['range'] = $range;
-								
+
 								// send back the original coords
 								$result['coords'] = [ $lat, $lng ];
-								
+
 								// lon -> lng
 								$result['lng'] = $result['lon'];
-								
+
 								// province abbreviation
 								$result['province_short'] = short_province ( $result['province'] );
-								
+
 								// nice name
 								$result['title'] = $result['geo_name'] . ', ' . $result['province_short'];
-								
+
 								$found_community = true;
-								
+
 								break;
 							}
 						}
-						
+
 					}
-					
+
 				}
-				
+
 			}
-			
+
 			if ( $found_community == true ) {
-				
+
 				// found a community in range
 				echo json_encode ( $result );
-				
+
 			} else {
-				
+
 				// no preferred results, grab the nearest one
-	
+
 				// range of coordinates to search between
 				$range = 0.1;
-				
+
 				$main_query = mysqli_query($GLOBALS['vars']['con'], "SELECT " . implode(",", $columns) . "
 				, DISTANCE_BETWEEN($lat, $lng, lat,lon) as distance
 				FROM all_areas
@@ -451,20 +451,20 @@ function cdc_get_location_by_coords () {
 				AND gen_term NOT IN ('Railway Point', 'Railway Junction', 'Urban Community', 'Administrative Sector')
 				ORDER BY DISTANCE
 				LIMIT 1");// or die (mysqli_error($GLOBALS['vars']['con']));
-				
+
 				if ($main_query->num_rows > 0) {
-					
+
 					$result = mysqli_fetch_assoc ( $main_query );
-					
+
 					$result['coords'] = [ $lat, $lng ];
 					$result['lng'] = $result['lon'];
 					$result['province_short'] = short_province ( $result['province'] );
 					$result['title'] = $result['geo_name'] . ', ' . $result['province_short'];
-					
+
 					echo json_encode ( $result );
-					
+
 				} else {
-					
+
 					echo json_encode ( array (
 						'lat' => $lat,
 						'lng' => $lng,
@@ -472,13 +472,13 @@ function cdc_get_location_by_coords () {
 						'geo_name' => __ ( 'Point', 'cdc' ),
 						'title' => __ ( 'Point', 'cdc' ) . ' (' . number_format ( $lat, 4, '.', '') . ', ' . number_format ( $lng, 4, '.', '') . ')'
 					) );
-					
+
 				}
-				
+
 			}
-			
+
 		} // if db.php
-	
+
 	} // if $_GET
 
 }
@@ -486,40 +486,40 @@ function cdc_get_location_by_coords () {
 // LOCATION SEARCH
 
 add_action ( 'rest_api_init', function () {
-	
+
 	register_rest_route ( 'cdc/v2', '/location_search/', array (
-		'methods' => 'GET', 
-		'callback' => 'cdc_location_search' 
+		'methods' => 'GET',
+		'callback' => 'cdc_location_search'
 	) );
-	
+
 });
 
 function cdc_location_search() {
-	
+
 	if ( locate_template ( 'resources/app/db.php' ) == '' ) {
-		
+
 		echo json_encode ( array (
 			'error' => 'no db connection'
 		) );
-		
+
 	} else {
-		
+
 		require_once locate_template ( 'resources/app/db.php' );
-		
+
 		$con = $GLOBALS['vars']['con'];
-		
+
 		$get_sSearch = isset($_GET['q']) ? $_GET['q'] : '';
 		$post_draw = isset($_POST['draw']) ? $_POST['draw'] : '';
-		
+
 		if (isset ( $GLOBALS['fw']['current_lang_code'] ) ){
 			$get_lang = $GLOBALS['fw']['current_lang_code'];
 		} else {
 			$get_lang = 'en';
 		}
-		
+
 		// the columns to be filtered, ordered and returned
 		// must be in the same order as displayed in the table
-		
+
 		$columns = array (
 			"id_code",
 			"geo_name",
@@ -529,7 +529,7 @@ function cdc_location_search() {
 			"lat",
 			"lon"
 		);
-		
+
 		if ( $get_lang == 'fr' ) {
 			$columns = array (
 				"id_code",
@@ -541,50 +541,50 @@ function cdc_location_search() {
 				"lon"
 			);
 		}
-		
+
 		$search_columns = [ "geo_name" ];
-		
+
 		$table = "all_areas";
 		$joins = "";
-		
+
 		$get_sSearch = str_replace('`','\'', $get_sSearch);
-		
+
 		// filtering
 		$sql_where = "where gen_term not in ('Administrative Region', 'Province', 'Territory') and geo_name like '%" . mysqli_real_escape_string ( $con,$get_sSearch ) . "%'" ;
-		
+
 		// ordering
 		$sql_order = "order by scale desc";
-		
+
 		$sql_limit = "";
-		
+
 		// paging if query string is shorter than 5
 		if ( strlen ( $get_sSearch ) < 5) {
 			$sql_limit = "LIMIT 0,10";
 		}
-		
+
 		$main_query = mysqli_query($con,"SELECT SQL_CALC_FOUND_ROWS " . implode(", ", $columns) . " FROM {$table} {$joins} {$sql_where} {$sql_order} {$sql_limit}")
 			or die ( mysqli_error ( $con ) );
-		
+
 		// send back the number requested
 		$response['draw'] = intval ( $post_draw );
-		
+
 		// get the number of filtered rows
-		
+
 		$filtered_rows_query = mysqli_query ( $con,"SELECT FOUND_ROWS()" )
 			or die ( mysqli_error ( $con ) );
-			
+
 		$row = mysqli_fetch_array ( $filtered_rows_query );
 		$response['recordsFiltered'] = $row[0];
-		
+
 		// get the number of rows in total
 		$total_query = mysqli_query ( $con,"SELECT COUNT(*) FROM {$table}" )
 			or die ( mysqli_error ( $con ) );
-			
+
 		$row = mysqli_fetch_array ( $total_query );
 		$response['recordsTotal'] = $row[0];
-		
+
 		$response['items'] = array();
-		
+
 		// finish getting rows from the main query
 		while ( $row = mysqli_fetch_row ( $main_query ) ) {
 			$row = array (
@@ -596,17 +596,17 @@ function cdc_location_search() {
 				"lat" => $row[5],
 				"lon" => $row[6]
 			);
-			
+
 			$response['items'][] = $row;
 		}
-		
+
 	} // locate db
-	
+
 	header('Cache-Control: no-cache');
 	header('Pragma: no-cache');
 	header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
 	header('Content-type: application/json');
-	
+
 	echo json_encode ( $response );
 
 }
@@ -618,12 +618,12 @@ function cdc_location_search() {
 // This script searches for IDF files matching the idf GET parameter and returns a JSON for the Frontend
 
 add_action ( 'rest_api_init', function () {
-	
+
 	register_rest_route ( 'cdc/v2', '/get_idf_url/', array (
-		'methods' => 'GET', 
-		'callback' => 'cdc_get_idf_url' 
+		'methods' => 'GET',
+		'callback' => 'cdc_get_idf_url'
 	) );
-	
+
 } );
 
 function cdc_get_idf_url () {
@@ -634,27 +634,27 @@ function cdc_get_idf_url () {
 	) {
 		return 'no file';
 	}
-		
+
 	// ensure input is alphanumeric
 	if ( !preg_match ( '/^[a-zA-Z0-9]+$/', $_GET['data'] ) ) {
 		return 'invalid';
 	}
-	
+
 	$result = array (
 		'glob' => get_stylesheet_directory() . '/resources/app/idf/' . $_GET['data'] . '/*' . $_GET['station'] . '*',
 		'files' => []
 	);
-	
+
 	$glob = glob ( get_stylesheet_directory() . '/resources/app/idf/' . $_GET['data'] . '/*' . $_GET['station'] . '*' );
-	
+
 	if ( !empty ( $glob ) ) {
 		foreach ( $glob as $file ) {
 			$result['files'][] = str_replace ( get_stylesheet_directory(), get_stylesheet_directory_uri(), $file );
 		}
 	}
-	
+
 	return $result;
-	
+
 }
 
 
@@ -840,7 +840,7 @@ function build_message_body ( $form_data, $form_type ) {
 	// Custom fields for feedback form
 	if ( $form_type == 'feedback' ) {
 		$body .= build_feedback_body ( $form_data );
-	} 
+	}
 	// Custom fields for apps form
 	elseif ( $form_type == 'apps' ) {
 		$body .= build_apps_body ( $form_data );
@@ -875,7 +875,7 @@ function build_feedback_body ( $form_data ) {
 
 	if ( isset( $form_data['role'] ) ) {
 		$body .= '<p><span style="display: inline-block; width: 150px; font-weight: bold; vertical-align: top;">Role</span><span style="display: inline-block; vertical-align: top;">' . esc_html( $form_data['role'] );
-	
+
 		if ( $form_data['role'] == 'Other' && $form_data['role-other'] != '' ) {
 			$body .= ': ' . esc_html( $form_data['role-other'] );
 		}
@@ -889,7 +889,7 @@ function build_feedback_body ( $form_data ) {
 		if ( $form_data['subject'] == 'Other' && $form_data['subject-other'] != '' ) {
 			$body .= ': ' . esc_html( $form_data['subject-other'] );
 		}
-	
+
 		$body .= '</span></p>';
 	}
 
@@ -928,4 +928,13 @@ function build_apps_body ( $form_data ) {
 
 	$body .= '</span></p>';
 	return $body;
+}
+
+/**
+ * Load REST API V3.
+ */
+$rest_v3_init_path = dirname( __FILE__ ) . '/rest-v3/init.php';
+
+if ( file_exists( $rest_v3_init_path ) ) {
+	require_once $rest_v3_init_path;
 }


### PR DESCRIPTION
## Description

This PR adds the necessary WP REST API endpoints to fetch datasets taxonomy terms and variables posts. This will be used on the map and downloads apps in the first steps of selecting a dataset and a variable.

In addition, this PR contains a missed ACF field regarding the dataset taxonomy term FR title.

## Related ticket

https://rm.ewdev.ca/issues/79666