### PR TITLE
refs: #78710: Fix map covering sidebar in mobile

### DIFF
--- a/apps/src/Global.css
+++ b/apps/src/Global.css
@@ -148,6 +148,11 @@
 
 /* map search control override styles */
 
+.leaflet-container .leaflet-control,
+.leaflet-control-container > div {
+	z-index: 30;
+}
+
 .leaflet-container .leaflet-control-search {
 	font-size: 14px;
 	display: flex;

--- a/apps/src/components/climate-data-chart.tsx
+++ b/apps/src/components/climate-data-chart.tsx
@@ -46,41 +46,220 @@ const ClimateDataChart: React.FC<{ title: string; data: ClimateDataProps }> = ({
 		]);
 	}, []);
 
-	const seriesObject = useMemo<Record<string, (SeriesLineOptions | SeriesArearangeOptions)[]>>(() => ({
-		'annual-values': [
-			{ custom: { key: 'gridded-historical' }, name: __('Gridded Historical Data'), type: 'line', data: sortByTimestamp(data.observations), color: 'gray', lineWidth: 1.5, dashStyle: 'ShortDash' } as SeriesLineOptions,
-			{ custom: { key: 'modeled-historical' }, name: __('Modeled Historical'), type: 'line', data: sortByTimestamp(data.modeled_historical_median), color: 'black', lineWidth: 2 } as SeriesLineOptions,
-			{ custom: { key: 'historical-range' }, name: __('Historical Range'), type: 'arearange', data: sortByTimestamp(data.modeled_historical_range), color: 'lightgray', fillOpacity: 0.3, zIndex: 0 } as SeriesArearangeOptions,
-			{ custom: { key: 'ssp126-median' }, name: __('SSP1-2.6 Median'), type: 'line', data: sortByTimestamp(data.ssp126_median), color: 'blue', lineWidth: 2 } as SeriesLineOptions,
-			{ custom: { key: 'ssp126-range' }, name: __('SSP1-2.6 Range'), type: 'arearange', data: sortByTimestamp(data.ssp126_range), color: 'lightblue', fillOpacity: 0.3 } as SeriesArearangeOptions,
-			{ custom: { key: 'ssp245-median' }, name: __('SSP2-4.5 Median'), type: 'line', data: sortByTimestamp(data.ssp245_median), color: 'green', lineWidth: 2 } as SeriesLineOptions,
-			{ custom: { key: 'ssp245-range' }, name: __('SSP2-4.5 Range'), type: 'arearange', data: sortByTimestamp(data.ssp245_range), color: 'lightgreen', fillOpacity: 0.3 } as SeriesArearangeOptions,
-			{ custom: { key: 'ssp585-median' }, name: __('SSP5-8.5 Median'), type: 'line', data: sortByTimestamp(data.ssp585_median), color: 'red', lineWidth: 2 } as SeriesLineOptions,
-			{ custom: { key: 'ssp585-range' }, name: __('SSP5-8.5 Range'), type: 'arearange', data: sortByTimestamp(data.ssp585_range), color: 'pink', fillOpacity: 0.3 } as SeriesArearangeOptions,
-		],
-		'30-year-averages': [
-			{ custom: { key: '30y-observations' }, name: __('30y Observations'), type: 'line', data: sortByTimestamp(formatData(data['30y_observations'])), color: 'black', lineWidth: 2 } as SeriesLineOptions,
-			{ custom: { key: '30y-ssp126-median' }, name: __('30y SSP1-2.6 Median'), type: 'line', data: sortByTimestamp(formatData(data['30y_ssp126_median'])), color: 'blue', lineWidth: 2 } as SeriesLineOptions,
-			{ custom: { key: '30y-ssp126-range' }, name: __('30y SSP1-2.6 Range'), type: 'arearange', data: sortByTimestamp(formatData(data['30y_ssp126_range'])), color: 'lightblue', fillOpacity: 0.3 } as SeriesArearangeOptions,
-			{ custom: { key: '30y-ssp245-median' }, name: __('30y SSP2-4.5 Median'), type: 'line', data: sortByTimestamp(formatData(data['30y_ssp245_median'])), color: 'green', lineWidth: 2 } as SeriesLineOptions,
-			{ custom: { key: '30y-ssp245-range' }, name: __('30y SSP2-4.5 Range'), type: 'arearange', data: sortByTimestamp(formatData(data['30y_ssp245_range'])), color: 'lightgreen', fillOpacity: 0.3 } as SeriesArearangeOptions,
-			{ custom: { key: '30y-ssp585-median' }, name: __('30y SSP5-8.5 Median'), type: 'line', data: sortByTimestamp(formatData(data['30y_ssp585_median'])), color: 'red', lineWidth: 2 } as SeriesLineOptions,
-			{ custom: { key: '30y-ssp585-range' }, name: __('30y SSP5-8.5 Range'), type: 'arearange', data: sortByTimestamp(formatData(data['30y_ssp585_range'])), color: 'pink', fillOpacity: 0.3 } as SeriesArearangeOptions,
-		],
-		'30-year-changes': [
-			{ custom: { key: 'delta7100-ssp126-median' }, name: __('Delta 7100 SSP1-2.6 Median'), type: 'line', data: sortByTimestamp(formatData(data['delta7100_ssp126_median'])), color: 'blue', lineWidth: 2 } as SeriesLineOptions,
-			{ custom: { key: 'delta7100-ssp126-range' }, name: __('Delta 7100 SSP1-2.6 Range'), type: 'arearange', data: sortByTimestamp(formatData(data['delta7100_ssp126_range'])), color: 'lightblue', fillOpacity: 0.3 } as SeriesArearangeOptions,
-			{ custom: { key: 'delta7100-ssp245-median' }, name: __('Delta 7100 SSP2-4.5 Median'), type: 'line', data: sortByTimestamp(formatData(data['delta7100_ssp245_median'])), color: 'green', lineWidth: 2 } as SeriesLineOptions,
-			{ custom: { key: 'delta7100-ssp245-range' }, name: __('Delta 7100 SSP2-4.5 Range'), type: 'arearange', data: sortByTimestamp(formatData(data['delta7100_ssp245_range'])), color: 'lightgreen', fillOpacity: 0.3 } as SeriesArearangeOptions,
-			{ custom: { key: 'delta7100-ssp585-median' }, name: __('Delta 7100 SSP5-8.5 Median'), type: 'line', data: sortByTimestamp(formatData(data['delta7100_ssp585_median'])), color: 'red', lineWidth: 2 } as SeriesLineOptions,
-			{ custom: { key: 'delta7100-ssp585-range' }, name: __('Delta 7100 SSP5-8.5 Range'), type: 'arearange', data: sortByTimestamp(formatData(data['delta7100_ssp585_range'])), color: 'pink', fillOpacity: 0.3 } as SeriesArearangeOptions,
-		]
-	}), [__, data, sortByTimestamp, formatData]);
+	const seriesObject = useMemo<
+		Record<string, (SeriesLineOptions | SeriesArearangeOptions)[]>
+	>(
+		() => ({
+			'annual-values': [
+				{
+					custom: { key: 'gridded-historical' },
+					name: __('Gridded Historical Data'),
+					type: 'line',
+					data: sortByTimestamp(data.observations),
+					color: 'gray',
+					lineWidth: 1.5,
+					dashStyle: 'ShortDash',
+				} as SeriesLineOptions,
+				{
+					custom: { key: 'modeled-historical' },
+					name: __('Modeled Historical'),
+					type: 'line',
+					data: sortByTimestamp(data.modeled_historical_median),
+					color: 'black',
+					lineWidth: 2,
+				} as SeriesLineOptions,
+				{
+					custom: { key: 'historical-range' },
+					name: __('Historical Range'),
+					type: 'arearange',
+					data: sortByTimestamp(data.modeled_historical_range),
+					color: 'lightgray',
+					fillOpacity: 0.3,
+					zIndex: 0,
+				} as SeriesArearangeOptions,
+				{
+					custom: { key: 'ssp126-median' },
+					name: __('SSP1-2.6 Median'),
+					type: 'line',
+					data: sortByTimestamp(data.ssp126_median),
+					color: 'blue',
+					lineWidth: 2,
+				} as SeriesLineOptions,
+				{
+					custom: { key: 'ssp126-range' },
+					name: __('SSP1-2.6 Range'),
+					type: 'arearange',
+					data: sortByTimestamp(data.ssp126_range),
+					color: 'lightblue',
+					fillOpacity: 0.3,
+				} as SeriesArearangeOptions,
+				{
+					custom: { key: 'ssp245-median' },
+					name: __('SSP2-4.5 Median'),
+					type: 'line',
+					data: sortByTimestamp(data.ssp245_median),
+					color: 'green',
+					lineWidth: 2,
+				} as SeriesLineOptions,
+				{
+					custom: { key: 'ssp245-range' },
+					name: __('SSP2-4.5 Range'),
+					type: 'arearange',
+					data: sortByTimestamp(data.ssp245_range),
+					color: 'lightgreen',
+					fillOpacity: 0.3,
+				} as SeriesArearangeOptions,
+				{
+					custom: { key: 'ssp585-median' },
+					name: __('SSP5-8.5 Median'),
+					type: 'line',
+					data: sortByTimestamp(data.ssp585_median),
+					color: 'red',
+					lineWidth: 2,
+				} as SeriesLineOptions,
+				{
+					custom: { key: 'ssp585-range' },
+					name: __('SSP5-8.5 Range'),
+					type: 'arearange',
+					data: sortByTimestamp(data.ssp585_range),
+					color: 'pink',
+					fillOpacity: 0.3,
+				} as SeriesArearangeOptions,
+			],
+			'30-year-averages': [
+				{
+					custom: { key: '30y-observations' },
+					name: __('30y Observations'),
+					type: 'line',
+					data: sortByTimestamp(formatData(data['30y_observations'])),
+					color: 'black',
+					lineWidth: 2,
+				} as SeriesLineOptions,
+				{
+					custom: { key: '30y-ssp126-median' },
+					name: __('30y SSP1-2.6 Median'),
+					type: 'line',
+					data: sortByTimestamp(
+						formatData(data['30y_ssp126_median'])
+					),
+					color: 'blue',
+					lineWidth: 2,
+				} as SeriesLineOptions,
+				{
+					custom: { key: '30y-ssp126-range' },
+					name: __('30y SSP1-2.6 Range'),
+					type: 'arearange',
+					data: sortByTimestamp(formatData(data['30y_ssp126_range'])),
+					color: 'lightblue',
+					fillOpacity: 0.3,
+				} as SeriesArearangeOptions,
+				{
+					custom: { key: '30y-ssp245-median' },
+					name: __('30y SSP2-4.5 Median'),
+					type: 'line',
+					data: sortByTimestamp(
+						formatData(data['30y_ssp245_median'])
+					),
+					color: 'green',
+					lineWidth: 2,
+				} as SeriesLineOptions,
+				{
+					custom: { key: '30y-ssp245-range' },
+					name: __('30y SSP2-4.5 Range'),
+					type: 'arearange',
+					data: sortByTimestamp(formatData(data['30y_ssp245_range'])),
+					color: 'lightgreen',
+					fillOpacity: 0.3,
+				} as SeriesArearangeOptions,
+				{
+					custom: { key: '30y-ssp585-median' },
+					name: __('30y SSP5-8.5 Median'),
+					type: 'line',
+					data: sortByTimestamp(
+						formatData(data['30y_ssp585_median'])
+					),
+					color: 'red',
+					lineWidth: 2,
+				} as SeriesLineOptions,
+				{
+					custom: { key: '30y-ssp585-range' },
+					name: __('30y SSP5-8.5 Range'),
+					type: 'arearange',
+					data: sortByTimestamp(formatData(data['30y_ssp585_range'])),
+					color: 'pink',
+					fillOpacity: 0.3,
+				} as SeriesArearangeOptions,
+			],
+			'30-year-changes': [
+				{
+					custom: { key: 'delta7100-ssp126-median' },
+					name: __('Delta 7100 SSP1-2.6 Median'),
+					type: 'line',
+					data: sortByTimestamp(
+						formatData(data['delta7100_ssp126_median'])
+					),
+					color: 'blue',
+					lineWidth: 2,
+				} as SeriesLineOptions,
+				{
+					custom: { key: 'delta7100-ssp126-range' },
+					name: __('Delta 7100 SSP1-2.6 Range'),
+					type: 'arearange',
+					data: sortByTimestamp(
+						formatData(data['delta7100_ssp126_range'])
+					),
+					color: 'lightblue',
+					fillOpacity: 0.3,
+				} as SeriesArearangeOptions,
+				{
+					custom: { key: 'delta7100-ssp245-median' },
+					name: __('Delta 7100 SSP2-4.5 Median'),
+					type: 'line',
+					data: sortByTimestamp(
+						formatData(data['delta7100_ssp245_median'])
+					),
+					color: 'green',
+					lineWidth: 2,
+				} as SeriesLineOptions,
+				{
+					custom: { key: 'delta7100-ssp245-range' },
+					name: __('Delta 7100 SSP2-4.5 Range'),
+					type: 'arearange',
+					data: sortByTimestamp(
+						formatData(data['delta7100_ssp245_range'])
+					),
+					color: 'lightgreen',
+					fillOpacity: 0.3,
+				} as SeriesArearangeOptions,
+				{
+					custom: { key: 'delta7100-ssp585-median' },
+					name: __('Delta 7100 SSP5-8.5 Median'),
+					type: 'line',
+					data: sortByTimestamp(
+						formatData(data['delta7100_ssp585_median'])
+					),
+					color: 'red',
+					lineWidth: 2,
+				} as SeriesLineOptions,
+				{
+					custom: { key: 'delta7100-ssp585-range' },
+					name: __('Delta 7100 SSP5-8.5 Range'),
+					type: 'arearange',
+					data: sortByTimestamp(
+						formatData(data['delta7100_ssp585_range'])
+					),
+					color: 'pink',
+					fillOpacity: 0.3,
+				} as SeriesArearangeOptions,
+			],
+		}),
+		[__, data, sortByTimestamp, formatData]
+	);
 
 	// adds visible property to each series
 	const filteredSeries = useMemo<SeriesOptionsType[]>(() => {
 		return (
-			seriesObject[activeTab]?.map(s => {
+			seriesObject[activeTab]?.map((s) => {
 				const baseSeries = {
 					...s,
 					visible: activeSeries.includes(s.custom?.key),
@@ -100,7 +279,9 @@ const ClimateDataChart: React.FC<{ title: string; data: ClimateDataProps }> = ({
 
 	// initialize activeSeries state with all leys  from the first tab
 	useEffect(() => {
-		setActiveSeries(seriesObject[activeTab]?.map(s => s.custom?.key) || []);
+		setActiveSeries(
+			seriesObject[activeTab]?.map((s) => s.custom?.key) || []
+		);
 	}, [activeTab, seriesObject]);
 
 	const chartOptions = useMemo<Options>(() => {
@@ -131,26 +312,26 @@ const ClimateDataChart: React.FC<{ title: string; data: ClimateDataProps }> = ({
 						},
 					},
 					title: {
-						text: title
+						text: title,
 					},
 					yAxis: {
 						title: {
-							text: title
-						}
-					}
+							text: title,
+						},
+					},
 				},
 				csv: {
-					dateFormat: '%Y-%m-%d'
-				}
+					dateFormat: '%Y-%m-%d',
+				},
 			},
 			legend: {
-				enabled: false,// using our own legend at the bottom with custom checkboxes
+				enabled: false, // using our own legend at the bottom with custom checkboxes
 			},
 			navigator: {
 				enabled: true,
 				adaptToUpdatedData: true,
 				height: 40,
-				margin: 30
+				margin: 30,
 			},
 			navigation: {
 				buttonOptions: {
@@ -200,7 +381,7 @@ const ClimateDataChart: React.FC<{ title: string; data: ClimateDataProps }> = ({
 					align: 'left',
 					formatter: function () {
 						return this.value + ' °C';
-					}
+					},
 					// formatter: function () {
 					// 	const value = this.axis.defaultLabelFormatter.call(this);
 					// 	if (localized_chart_unit === 'doy') {
@@ -209,7 +390,7 @@ const ClimateDataChart: React.FC<{ title: string; data: ClimateDataProps }> = ({
 					// 		return value + ' ' + localized_chart_unit;
 					// 	}
 					// }
-				}
+				},
 			},
 			// series: [{ name: 'Test Series', type: 'line', data: [[0, 1], [1, 2], [2, 3]], color: 'blue' }]
 			series: filteredSeries,
@@ -228,10 +409,12 @@ const ClimateDataChart: React.FC<{ title: string; data: ClimateDataProps }> = ({
 	const rangeLabel: string = 'Range';
 
 	return (
-		<div className="climate-chart z-[500] px-5 py-5">
+		<div className="climate-chart px-5 py-5">
 			<div className="flex justify-between items-start mb-4">
 				<div className="text-left">
-					<h2 className="text-2xl text-cdc-black font-semibold leading-7 m-0">{title}</h2>
+					<h2 className="text-2xl text-cdc-black font-semibold leading-7 m-0">
+						{title}
+					</h2>
 					<p className="text-sm text-neutral-grey-medium leading-5 m-0">
 						{__(
 							'Historical Canadian Climate Normals – Hottest Day – CMIP6'
@@ -302,7 +485,9 @@ const ClimateDataChart: React.FC<{ title: string; data: ClimateDataProps }> = ({
 					</button>
 				</div>
 				<div className="flex justify-end items-center gap-2">
-					<span className="text-dark-purple text-xs font-semibold uppercase leading-4">{__('Export')}</span>
+					<span className="text-dark-purple text-xs font-semibold uppercase leading-4">
+						{__('Export')}
+					</span>
 					<button
 						className="text-xs text-cdc-black font-semibold leading-4 tracking-wide py-1 px-3 border border-soft-purple uppercase cursor-pointer"
 						onClick={() => handleExport('PDF')}
@@ -335,15 +520,20 @@ const ClimateDataChart: React.FC<{ title: string; data: ClimateDataProps }> = ({
 			{/* toggle visibility of series points */}
 			<div className="flex flex-wrap items-center justify-center gap-4 my-2 mx-12">
 				{filteredSeries.map((s: SeriesOptionsType, index: number) => (
-					<label key={index} className="flex items-center gap-1 cursor-pointer select-none">
+					<label
+						key={index}
+						className="flex items-center gap-1 cursor-pointer select-none"
+					>
 						{/* toggle input */}
 						<input
 							type="checkbox"
 							checked={s.visible}
 							onChange={() => {
-								setActiveSeries(prev =>
+								setActiveSeries((prev) =>
 									prev.includes(s.custom?.key ?? '')
-										? prev.filter(key => key !== s.custom?.key)
+										? prev.filter(
+												(key) => key !== s.custom?.key
+											)
 										: [...prev, s.custom?.key ?? '']
 								);
 							}}
@@ -355,7 +545,9 @@ const ClimateDataChart: React.FC<{ title: string; data: ClimateDataProps }> = ({
 							className="w-4 h-4 rounded-full"
 							style={{
 								backgroundColor:
-									'color' in s && typeof s.color === 'string' ? s.color : 'transparent',
+									'color' in s && typeof s.color === 'string'
+										? s.color
+										: 'transparent',
 							}}
 						/>
 

--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -73,31 +73,34 @@ const MapHeader: React.FC<MapInfoProps> = ({
 	};
 
 	return (
-		<aside className="map-header">
-			<div
-				ref={ref}
-				className="absolute top-0 left-0 z-[9999] overflow-y-auto w-full"
-			>
-				<div className="flex items-center gap-x-2 bg-white p-4">
-					<Breadcrumbs
-						title={data.title}
-						onClick={toggleVariableDetailsPanel}
-					/>
-					<ModalToggleButtons
-						onToggleShare={toggleShareInfo}
-						onToggleDownload={toggleDownloadInfo}
-					/>
+		<>
+			<aside className="map-header relative z-20">
+				<div
+					ref={ref}
+					className="absolute top-0 left-0 overflow-y-auto w-full"
+				>
+					<div className="flex items-center gap-x-2 bg-white p-4">
+						<Breadcrumbs
+							title={data.title}
+							onClick={toggleVariableDetailsPanel}
+						/>
+						<ModalToggleButtons
+							onToggleShare={toggleShareInfo}
+							onToggleDownload={toggleDownloadInfo}
+						/>
+					</div>
 				</div>
+			</aside>
 
-				<ShareMapModal isOpen={shareInfo} onClose={toggleShareInfo} />
-				<DownloadMapModal
-					isOpen={downloadInfo}
-					onClose={toggleDownloadInfo}
-					title={data.title}
-					mapRef={mapRef}
-				/>
-			</div>
-		</aside>
+			{/* moved outside of the map header container for the modal overaly to cover also the sidebar*/}
+			<ShareMapModal isOpen={shareInfo} onClose={toggleShareInfo} />
+			<DownloadMapModal
+				isOpen={downloadInfo}
+				onClose={toggleDownloadInfo}
+				title={data.title}
+				mapRef={mapRef}
+			/>
+		</>
 	);
 };
 MapHeader.displayName = 'MapHeader';

--- a/apps/src/components/map-layers/custom-panes.ts
+++ b/apps/src/components/map-layers/custom-panes.ts
@@ -12,6 +12,13 @@ export default function CustomPanesLayer(): null {
 	const map = useMap();
 
 	useEffect(() => {
+		// target the main leaflet-map-pane element
+		const mapPane = map.getPane('mapPane');
+		if (mapPane) {
+			// apply custom z-index class to avoid it being too high
+			mapPane.classList.add('z-20');
+		}
+
 		// Used for the primary map tiles or base layers.
 		// Non-interactive with the lowest z-index to ensure it's below other elements.
 		map.createPane('basemap');

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -151,7 +151,7 @@ export default function SearchControl({
 	return (
 		<div
 			className={cn(
-				'search-control absolute top-24 left-4 z-[9999] flex items-center space-x-1',
+				'search-control absolute top-24 left-4 z-20 flex items-center space-x-1',
 				className
 			)}
 		>

--- a/apps/src/components/map-wrapper.tsx
+++ b/apps/src/components/map-wrapper.tsx
@@ -66,7 +66,7 @@ export default function MapWrapper() {
 				ref={wrapperRef}
 				className={cn(
 					'map-wrapper',
-					'grid gap-4 h-full',
+					'grid gap-4 h-full z-30',
 					showComparisonMap ? 'sm:grid-cols-2' : 'grid-cols-1'
 				)}
 			>

--- a/apps/src/components/map.tsx
+++ b/apps/src/components/map.tsx
@@ -40,6 +40,7 @@ export default function Map({
 			minZoom={DEFAULT_MIN_ZOOM}
 			maxZoom={DEFAULT_MAX_ZOOM}
 			scrollWheelZoom={true}
+			className="z-10" // important to keep the map below other interactive elements
 		>
 			<MapEvents onMapReady={onMapReady} onUnmount={onUnmount} />
 			<MapLegend />

--- a/apps/src/components/ui/animated-panel.tsx
+++ b/apps/src/components/ui/animated-panel.tsx
@@ -69,7 +69,7 @@ const AnimatedPanel: React.FC<AnimatedPanelProps> = ({
 						...position, // may override left/right defaults if provided
 					}}
 					className={cn(
-						'absolute bg-white shadow-sm z-[99998]',
+						'absolute bg-white shadow-sm z-40',
 						className
 					)}
 				>

--- a/apps/src/components/ui/color-select.tsx
+++ b/apps/src/components/ui/color-select.tsx
@@ -54,7 +54,7 @@ export const ColorSelect: React.FC<ColorSelectProps> = ({
 			{isOpen && (
 				<ul
 					role="listbox"
-					className="absolute top-full left-0 z-10 bg-white border border-gray-300 rounded mt-1 p-0 list-none w-full"
+					className="absolute top-full left-0 z-50 bg-white border border-gray-300 rounded mt-1 p-0 list-none w-full"
 				>
 					{options.map((option, index) => (
 						<li

--- a/apps/src/components/ui/dropdown.tsx
+++ b/apps/src/components/ui/dropdown.tsx
@@ -84,13 +84,13 @@ const DropdownGeneric = <T extends string | undefined>(
 	};
 
 	return (
-		<div ref={ref} className={cn('dropdown z-[99999]', className)}>
+		<div ref={ref} className={cn('dropdown z-50', className)}>
 			{label && <ControlTitle title={label} tooltip={tooltip} />}
 			<Select value={value} onValueChange={handleValueChanged}>
 				<SelectTrigger className="w-full focus:ring-0 focus:ring-offset-0 text-cdc-black [&>svg]:text-brand-blue [&>svg]:opacity-100">
 					<SelectValue placeholder={placeholderTranslated} />
 				</SelectTrigger>
-				<SelectContent className="z-[99999]">
+				<SelectContent>
 					{/* TODO: this stopped working after fixing typescript errors.. revisit and unhide!! */}
 					{searchable && (
 						<div className="p-2 hidden">

--- a/apps/src/components/ui/modal.tsx
+++ b/apps/src/components/ui/modal.tsx
@@ -26,7 +26,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
 
 		return (
 			<div
-				className="modal fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-[9999]"
+				className="modal fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
 				onClick={onClose}
 				role="presentation" // Indicates the backdrop is a background presentation element
 				aria-hidden={!isOpen} // Ensures the backdrop is ignored by screen readers when modal is not open

--- a/apps/src/components/ui/popover.tsx
+++ b/apps/src/components/ui/popover.tsx
@@ -28,7 +28,7 @@ const PopoverContent = forwardRef<
 			align={align}
 			sideOffset={sideOffset}
 			className={cn(
-				'popover-content z-[99999]',
+				'popover-content z-50',
 				'w-full p-4 rounded-md border',
 				'bg-popover text-popover-foreground shadow-md outline-none',
 				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',

--- a/apps/src/components/ui/sheet.tsx
+++ b/apps/src/components/ui/sheet.tsx
@@ -17,7 +17,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
 	<SheetPrimitive.Overlay
 		className={cn(
-			'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+			'fixed inset-0 z-40 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
 			className
 		)}
 		{...props}
@@ -27,7 +27,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-	'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+	'fixed z-40 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
 	{
 		variants: {
 			side: {

--- a/apps/src/components/ui/sidebar.tsx
+++ b/apps/src/components/ui/sidebar.tsx
@@ -186,7 +186,7 @@ const SidebarRail = React.forwardRef<
 			onClick={toggleSidebar}
 			title="Toggle Sidebar"
 			className={cn(
-				'absolute inset-y-0 z-50 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
+				'absolute inset-y-0 z-30 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
 				'[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize',
 				'[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
 				'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar',

--- a/apps/src/components/ui/sidebar.tsx
+++ b/apps/src/components/ui/sidebar.tsx
@@ -104,7 +104,7 @@ const Sidebar = React.forwardRef<
 		return (
 			<div
 				ref={ref}
-				className="sidebar z-[99999] group peer hidden md:block text-sidebar-foreground"
+				className="sidebar z-30 relative group peer hidden md:block text-sidebar-foreground"
 				data-state={state}
 				data-collapsible={state === 'collapsed' ? collapsible : ''}
 				data-variant={variant}
@@ -121,8 +121,7 @@ const Sidebar = React.forwardRef<
 				/>
 				<div
 					className={cn(
-						'duration-200 fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex',
-						'z-[99999]', // this shows the sidebar above the sliding content component when present
+						'duration-200 fixed inset-y-0 hidden h-svh w-[--sidebar-width] transition-[left,right,width] ease-linear md:flex',
 						sideClasses,
 						variantPaddingClasses,
 						className
@@ -187,7 +186,7 @@ const SidebarRail = React.forwardRef<
 			onClick={toggleSidebar}
 			title="Toggle Sidebar"
 			className={cn(
-				'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
+				'absolute inset-y-0 z-50 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
 				'[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize',
 				'[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
 				'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar',

--- a/apps/src/components/ui/zoom-buttons.tsx
+++ b/apps/src/components/ui/zoom-buttons.tsx
@@ -28,7 +28,7 @@ const ZoomButtons: React.FC<ZoomControlProps> = ({
 	);
 
 	return (
-		<div className="absolute bottom-6 left-6 z-[9999] overflow-y-auto">
+		<div className="absolute bottom-6 left-6 z-20 overflow-y-auto">
 			<div
 				className={cn(
 					'zoom-control',


### PR DESCRIPTION
## Description

This PR fixes the map covering the sidebar in mobile, and also fixes z-index property for relevant components, by grouping them by their purpose. eg. dropdowns, tooltips, context menus, full size modal were added z-50 class, animated panels were added z-40, sidebar and map wrapper were added z-30, and so on.

## Related ticket
