### PR TITLE
CLIM-866: Increase the size of icons and associated text in the sidebar

### DIFF
--- a/fw-child/resources/scss/child.scss
+++ b/fw-child/resources/scss/child.scss
@@ -521,7 +521,7 @@ $control-slider-handle-width: 2.75rem;
     transition: 0.25s;
 
     @include media-breakpoint-up(md) {
-      font-size: 0.75rem;
+      font-size: 0.85rem;
     }
 
     &.disabled {
@@ -556,14 +556,14 @@ $control-slider-handle-width: 2.75rem;
     }
 
     svg {
-      width: 22px;
+      width: 25px;
 
       @include media-breakpoint-up(lg) {
-        width: 24px;
+        width: 27px;
       }
 
       @include media-breakpoint-up(xl) {
-        width: 30px;
+        width: 35px;
       }
     }
   }


### PR DESCRIPTION
## Description

Icons and text were too small, affecting readability and user experience.
This PR increases them, improving readability and user experience.

## Related ticket

CLIM-866