### PR TITLE
refs: #81968 Fix Typography issues: missing fonts

### DIFF
--- a/apps/src/Global.css
+++ b/apps/src/Global.css
@@ -119,30 +119,30 @@
 @font-face {
 	font-family: "CDCSerif";
 	font-weight: normal;
-	src: url("@fonts/CDCSerif-Medium.woff2") format("woff2");
+	src: url("./../../resources/fonts/CDCSerif-Medium.woff2") format("woff2");
 }
 
 @font-face {
 	font-family: "CDCSerif";
 	font-weight: bold;
-	src: url("@fonts/CDCSerif-Bold.woff2") format("woff2");
+	src: url("./../../resources/fonts/CDCSerif-Bold.woff2") format("woff2");
 }
 
 @font-face {
 	font-family: "CDCSans";
-	src: url("@fonts/CDCSans-Light.woff2");
+	src: url("./../../resources/fonts/CDCSans-Light.woff2");
 	font-weight: normal;
 }
 
 @font-face {
 	font-family: "CDCSans";
-	src: url("@fonts/CDCSans-Book.woff2");
+	src: url("./../../resources/fonts/CDCSans-Book.woff2");
 	font-weight: 500;
 }
 
 @font-face {
 	font-family: "CDCSans";
-	src: url("@fonts/CDCSans-SemiBold.woff2");
+	src: url("./../../resources/fonts/CDCSans-SemiBold.woff2");
 	font-weight: 600;
 }
 


### PR DESCRIPTION
# Resolves the missing fonts in the WP version.

Here is the history of comments which led to this decision from the old PR and deleted branch.

## Description

In both the map and the download apps, the typography wasn't applied properly.
There existed console errors such as:

```js
GET https://dev-en.climatedata.ca/CDCSans-Light--aGvsYLY.woff2 net::ERR_ABORTED 404 (Not Found)
```

Examined different ways to load the fonts via `vite.config.ts` including:
- Adding base to the vite config to match the url where app is served
- Leveraging vite\'s publicDir to load the fonts
- Using relative path to load the fonts instead of alias
- directly importing the fonts in `App.ts`

None of the above worked.

The next step was to load a separate font file via vite as a separate entry in addition to explicitly adding it to the templates via the `cdc_app_asset_load()` function. That did not work either.

The last resort was to by-pass all the build processes and load the fonts directly in the templates from the theme\'s assets and to be written directly in the templates head element which resolved the issue.

## How to test:

Navigate to `https://dev-en.climatedata.ca/map-app/` and open the browser console, the errors regarding the missing fonts are gone and font styles are being applied to the app as per the design comps.

In the same way, the standalone app also works since the font assets there are being managed directly by vite.

---

@mahieddineak Commented:
thanks for the detailed explanation. I had a quick review and I note that in the file `/apps/src/Global.css` there are already `@font-face` definitions, which might lead to duplicated CSS code. Once changing the URL paths as following, the fonts will load properly as of my testing:

```css
@font-face {
	font-family: "CDCSerif";
	font-weight: normal;
	src: url("./../../resources/fonts/CDCSerif-Medium.woff2") format("woff2");
}

@font-face {
	font-family: "CDCSerif";
	font-weight: bold;
	src: url("./../../resources/fonts/CDCSerif-Bold.woff2") format("woff2");
}

@font-face {
	font-family: "CDCSans";
	src: url("./../../resources/fonts/CDCSans-Light.woff2");
	font-weight: normal;
}

@font-face {
	font-family: "CDCSans";
	src: url("./../../resources/fonts/CDCSans-Book.woff2");
	font-weight: 500;
}

@font-face {
	font-family: "CDCSans";
	src: url("./../../resources/fonts/CDCSans-SemiBold.woff2");
	font-weight: 600;
}
```

Could you look into that please? As we might not need a PHP solution for the fonts loading.

---

@alinademi commented:
> I had a quick review and I note that in the file `/apps/src/Global.css` there are already `@font-face` definitions, which might lead to duplicated CSS code. Once changing the URL paths as following, the fonts will load properly as of my testing...

@mahieddineak I did test this before, however, I did not get the same results as you got in my tests. The build command results in:

```console
./../../resources/fonts/CDCSerif-Medium.woff2 referenced in ./../../resources/fonts/CDCSerif-Medium.woff2 didn't resolve at build time, it will remain unchanged to be resolved at runtime
```

As a result, the fonts will be available in `https://dev-en.climatedata.ca/map-app/` but will break the standalone app in localhost which we are using for dev. As for the code in global css I left it for the dev non WP version to work. 

Dev:
![image](https://github.com/user-attachments/assets/a1e0742d-c17a-4712-a194-c42de8a86e3b)

Please verify this in your test.

---

👇🏼 👇🏼 👇🏼 
@mahieddineak commneted:
that is fine, as our intention is for the fonts to load in the app on WP page, this app isn't meant to be standalone.