### PR TITLE
refs: #81974: output breadcrumb chain dynamically

### DIFF
--- a/apps/.prettierrc
+++ b/apps/.prettierrc
@@ -1,1 +1,8 @@
-{ }
+{
+	"useTabs": true,
+	"tabWidth": 2,
+	"endOfLine": "lf",
+	"semi": true,
+	"singleQuote": true,
+	"trailingComma": "es5"
+}

--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -125,7 +125,7 @@ const Breadcrumbs: React.FC<{ title: string; onClick: () => void }> = ({
 	const variableTitle = useMemo(() => {
 		if (!climateVariable) return title;
 
-		return climateVariable.getTitle() || __(climateVariable.getId()) || title;
+		return climateVariable.getTitle() || title;
 	}, [climateVariable, __, title]);
 
 	return (

--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -126,7 +126,7 @@ const Breadcrumbs: React.FC<{ title: string; onClick: () => void }> = ({
 		if (!climateVariable) return title;
 
 		return climateVariable.getTitle() || title;
-	}, [climateVariable, __, title]);
+	}, [climateVariable, title]);
 
 	return (
 		<div className="flex items-center gap-2">

--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -22,6 +22,7 @@ import { useAnimatedPanel } from '@/hooks/use-animated-panel';
 import { MapInfoProps, ProviderPanelProps } from '@/types/types';
 import { useLocale } from '@/hooks/use-locale';
 import { useAppSelector } from "@/app/hooks";
+import { useClimateVariable } from "@/hooks/use-climate-variable";
 
 /**
  * MapHeader component, displays the header for the map with breadcrumbs and buttons for extra information.
@@ -112,29 +113,34 @@ const Breadcrumbs: React.FC<{ title: string; onClick: () => void }> = ({
   const { __ } = useI18n();
   const { locale } = useLocale();
   const dataset = useAppSelector((state) => state.map.dataset);
-
-  console.log(dataset);
+  const { climateVariable } = useClimateVariable();
 
   const datasetName = useMemo(() => {
     if (!dataset) return '';
-
     return locale === 'fr' && dataset.title.fr
       ? dataset.title.fr
       : dataset.title.en;
   }, [dataset, locale]);
 
+  const variableTitle = useMemo(() => {
+    if (!climateVariable) return title;
+
+    return __(climateVariable.getId()) || title;
+
+  }, [climateVariable, __, title]);
+
   return (
     <div className="flex items-center gap-2">
       {datasetName && <span>{datasetName}</span>}
-      {datasetName && title && <span>/</span>}
-      {title && (
+      {datasetName && variableTitle && <span>/</span>}
+      {variableTitle && (
         <Button
           variant="ghost"
           className="text-md text-cdc-black hover:text-dark-purple hover:bg-transparent p-0 h-auto"
           onClick={onClick}
           aria-label={__('View details')}
         >
-          {title}
+          {variableTitle}
           <Info />
         </Button>
       )}

--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -107,45 +107,44 @@ MapHeader.displayName = 'MapHeader';
  * Breadcrumbs component, displays the breadcrumbs for the selected state of the map.
  */
 const Breadcrumbs: React.FC<{ title: string; onClick: () => void }> = ({
-  title,
-  onClick,
+	title,
+	onClick,
 }) => {
-  const { __ } = useI18n();
-  const { locale } = useLocale();
-  const dataset = useAppSelector((state) => state.map.dataset);
-  const { climateVariable } = useClimateVariable();
+	const { __ } = useI18n();
+	const { locale } = useLocale();
+	const dataset = useAppSelector((state) => state.map.dataset);
+	const { climateVariable } = useClimateVariable();
 
-  const datasetName = useMemo(() => {
-    if (!dataset) return '';
-    return locale === 'fr' && dataset.title.fr
-      ? dataset.title.fr
-      : dataset.title.en;
-  }, [dataset, locale]);
+	const datasetName = useMemo(() => {
+		if (!dataset) return '';
+		return locale === 'fr' && dataset.title.fr
+			? dataset.title.fr
+			: dataset.title.en;
+	}, [dataset, locale]);
 
-  const variableTitle = useMemo(() => {
-    if (!climateVariable) return title;
+	const variableTitle = useMemo(() => {
+		if (!climateVariable) return title;
 
-    return __(climateVariable.getId()) || title;
+		return climateVariable.getTitle() || __(climateVariable.getId()) || title;
+	}, [climateVariable, __, title]);
 
-  }, [climateVariable, __, title]);
-
-  return (
-    <div className="flex items-center gap-2">
-      {datasetName && <span>{datasetName}</span>}
-      {datasetName && variableTitle && <span>/</span>}
-      {variableTitle && (
-        <Button
-          variant="ghost"
-          className="text-md text-cdc-black hover:text-dark-purple hover:bg-transparent p-0 h-auto"
-          onClick={onClick}
-          aria-label={__('View details')}
-        >
-          {variableTitle}
-          <Info />
-        </Button>
-      )}
-    </div>
-  );
+	return (
+		<div className="flex items-center gap-2">
+			{datasetName && <span>{datasetName}</span>}
+			{datasetName && variableTitle && <span>/</span>}
+			{variableTitle && (
+				<Button
+					variant="ghost"
+					className="text-md text-cdc-black hover:text-dark-purple hover:bg-transparent p-0 h-auto"
+					onClick={onClick}
+					aria-label={__('View details')}
+				>
+					{variableTitle}
+					<Info />
+				</Button>
+			)}
+		</div>
+	);
 };
 Breadcrumbs.displayName = 'Breadcrumbs';
 

--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -81,7 +81,6 @@ const MapHeader: React.FC<MapInfoProps> = ({ data }): React.ReactElement => {
 				>
 					<div className="flex items-center gap-x-2 bg-white p-4">
 						<Breadcrumbs
-							title={data.title}
 							onClick={toggleVariableDetailsPanel}
 						/>
 						<ModalToggleButtons
@@ -106,8 +105,7 @@ MapHeader.displayName = 'MapHeader';
 /**
  * Breadcrumbs component, displays the breadcrumbs for the selected state of the map.
  */
-const Breadcrumbs: React.FC<{ title: string; onClick: () => void }> = ({
-	title,
+const Breadcrumbs: React.FC<{ onClick: () => void }> = ({
 	onClick,
 }) => {
 	const { __ } = useI18n();
@@ -123,10 +121,13 @@ const Breadcrumbs: React.FC<{ title: string; onClick: () => void }> = ({
 	}, [dataset, locale]);
 
 	const variableTitle = useMemo(() => {
-		if (!climateVariable) return title;
+		if (climateVariable && climateVariable.toObject().postId) {
+			return climateVariable.getTitle() || '';
+		}
 
-		return climateVariable.getTitle() || title;
-	}, [climateVariable, title]);
+		// Don't show anything if no variable is explicitly selected
+		return '';
+	}, [climateVariable]);
 
 	return (
 		<div className="flex items-center gap-2">

--- a/apps/src/context/climate-variable-provider.tsx
+++ b/apps/src/context/climate-variable-provider.tsx
@@ -101,6 +101,7 @@ export const ClimateVariableProvider: React.FC<{ children: React.ReactNode }> = 
 			dispatch(setClimateVariable({
 				...matchedVariable,
 				postId: variable.postId,
+				title: variable.title
 			}));
 		} else {
 			throw new Error(`No matching variable found for id: ${variable.id}`);

--- a/apps/src/context/locale-provider.tsx
+++ b/apps/src/context/locale-provider.tsx
@@ -6,22 +6,31 @@
  * in the future a language switcher is implemented.
  *
  */
-import React, { createContext } from 'react';
+import React, { createContext, useState, useEffect } from 'react';
 import { Locale } from '@/types/types';
 
 // Define the LocaleContext
-const LocaleContext = createContext<{ locale: Locale }>({ locale: 'en' });
+const LocaleContext = createContext<{ locale: Locale; setLocale: (locale: Locale) => void } | undefined>(undefined);
 
 // Provider component
 export const LocaleProvider: React.FC<{ children: React.ReactNode }> = ({
 	children,
 }) => {
 	const rootElement = document.getElementById('root');
-	const locale =
-		(rootElement?.getAttribute('data-app-lang') as Locale) || 'en';
+	const initialLocale = (rootElement?.getAttribute('data-app-lang') as Locale) || 'en';
+
+	const [locale, setLocale] = useState<Locale>(initialLocale);
+
+	useEffect(() => {
+		// Client-side locale
+		const browserLocale = navigator.language;
+		if (browserLocale.startsWith('fr')) {
+			setLocale('fr');
+		}
+	}, []);
 
 	return (
-		<LocaleContext.Provider value={{ locale: locale as Locale }}>
+		<LocaleContext.Provider value={{ locale, setLocale }}>
 			{children}
 		</LocaleContext.Provider>
 	);

--- a/apps/src/hooks/use-locale.ts
+++ b/apps/src/hooks/use-locale.ts
@@ -6,7 +6,7 @@ import { LocaleContext } from '@/context/locale-provider';
 
 export const useLocale = () => {
 	const context = useContext(LocaleContext);
-	if (!context) {
+	if (context === undefined) {
 		throw new Error('useLocale must be used within a LocaleProvider');
 	}
 

--- a/apps/src/lib/climate-variable-base.tsx
+++ b/apps/src/lib/climate-variable-base.tsx
@@ -33,6 +33,10 @@ class ClimateVariableBase implements ClimateVariableInterface {
 		return this._config.id;
 	}
 
+	getTitle(): string | null {
+		return this._config.title || null;
+	}
+
 	getVersions(): string[] {
 		return this._config.versions ?? [];
 	}

--- a/apps/src/lib/climate-variable-base.tsx
+++ b/apps/src/lib/climate-variable-base.tsx
@@ -33,8 +33,18 @@ class ClimateVariableBase implements ClimateVariableInterface {
 		return this._config.id;
 	}
 
-	getTitle(): string | null {
-		return this._config.title || null;
+	getTitle(locale?: string): string | null {
+		const title = this._config.title;
+
+		if (title && typeof title !== 'string' && 'en' in title) {
+
+				if (locale === 'fr' && title.fr) {
+						return title.fr;
+				}
+				return title.en;
+		}
+
+		return title as string || null;
 	}
 
 	getVersions(): string[] {

--- a/apps/src/types/climate-variable-interface.ts
+++ b/apps/src/types/climate-variable-interface.ts
@@ -1,4 +1,5 @@
 import React from "react";
+import { MultilingualField } from "./types";
 
 export interface ScenariosConfig {
 	[key: string]: string[];
@@ -102,7 +103,7 @@ export interface ClimateVariableConfigInterface {
 	postId?: number;
 
 	/** Title of the climate variable from the API */
-	title?: string;
+	title?: string | MultilingualField;
 
 	/** Class name defining the type or category of the climate variable */
 	class: string;

--- a/apps/src/types/climate-variable-interface.ts
+++ b/apps/src/types/climate-variable-interface.ts
@@ -101,6 +101,9 @@ export interface ClimateVariableConfigInterface {
 	/** WordPress Post ID, used for backend operations (optional) */
 	postId?: number;
 
+	/** Title of the climate variable from the API */
+	title?: string;
+
 	/** Class name defining the type or category of the climate variable */
 	class: string;
 
@@ -207,6 +210,8 @@ export interface ClimateVariableConfigInterface {
  */
 export interface ClimateVariableInterface {
 	getId(): string;
+
+	getTitle(): string | null;
 
 	getVersions(): string[];
 

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -193,7 +193,7 @@ export interface MapState {
 	frequency: string;
 	timePeriodEnd: number[]; // using an array because the slider that uses it expects an array
 	recentLocations: MapLocation[];
-	variable: string;
+	variable: ApiPostData | string;
 	dataset?: TaxonomyData;
 	decade: string;
 	pane: string;
@@ -571,71 +571,4 @@ export interface ChoroValuesOptions {
 	interactiveRegion: string;
 	emissionScenario: string;
 	decimals: number;
-}
-
-/**
- * Represents the structure of variable metadata from the API
- */
-export interface VariableMetadata {
-  'updated-on': string;
-  content: {
-    title: MultilingualField;
-    thumbnail?: string;
-  };
-  taxonomy: {
-    sector: { terms: TermItem[] };
-    region: { terms: TermItem[] };
-    'var-type': { terms: TermItem[] };
-    'variable-datasets': { terms: TermItem[] };
-  };
-}
-
-/**
- * Represents a variable item from the API response
- */
-export interface VariableItem {
-  id: null | string | number;
-  post_id: number;
-  meta: VariableMetadata;
-}
-
-/**
- * Represents the API response structure for variables
- */
-export interface VariablesResponse {
-  variables: VariableItem[];
-}
-
-/**
- * Represents the structure of a variable response extending TaxonomyData.
- */
-export interface VariableResponse extends TaxonomyData {
-  meta?: {
-    content: {
-      title: MultilingualField;
-      thumbnail?: string;
-    };
-    taxonomy?: {
-      sector: { terms: TermItem[] };
-      region: { terms: TermItem[] };
-      'var-type': { terms: TermItem[] };
-      'variable-datasets': { terms: TermItem[] };
-    };
-    'updated-on'?: string;
-  };
-}
-
-/**
- * Type guard helper to check if a taxonomy data object is a VariableResponse.
- */
-export function isVariableResponse(data: TaxonomyData): data is VariableResponse {
-  return (
-    'meta' in data &&
-    typeof data.meta === 'object' &&
-    data.meta !== null &&
-    'content' in data.meta &&
-    typeof data.meta.content === 'object' &&
-    data.meta.content !== null &&
-    'title' in data.meta.content
-  );
 }

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -572,3 +572,70 @@ export interface ChoroValuesOptions {
 	emissionScenario: string;
 	decimals: number;
 }
+
+/**
+ * Represents the structure of variable metadata from the API
+ */
+export interface VariableMetadata {
+  'updated-on': string;
+  content: {
+    title: MultilingualField;
+    thumbnail?: string;
+  };
+  taxonomy: {
+    sector: { terms: TermItem[] };
+    region: { terms: TermItem[] };
+    'var-type': { terms: TermItem[] };
+    'variable-datasets': { terms: TermItem[] };
+  };
+}
+
+/**
+ * Represents a variable item from the API response
+ */
+export interface VariableItem {
+  id: null | string | number;
+  post_id: number;
+  meta: VariableMetadata;
+}
+
+/**
+ * Represents the API response structure for variables
+ */
+export interface VariablesResponse {
+  variables: VariableItem[];
+}
+
+/**
+ * Represents the structure of a variable response extending TaxonomyData.
+ */
+export interface VariableResponse extends TaxonomyData {
+  meta?: {
+    content: {
+      title: MultilingualField;
+      thumbnail?: string;
+    };
+    taxonomy?: {
+      sector: { terms: TermItem[] };
+      region: { terms: TermItem[] };
+      'var-type': { terms: TermItem[] };
+      'variable-datasets': { terms: TermItem[] };
+    };
+    'updated-on'?: string;
+  };
+}
+
+/**
+ * Type guard helper to check if a taxonomy data object is a VariableResponse.
+ */
+export function isVariableResponse(data: TaxonomyData): data is VariableResponse {
+  return (
+    'meta' in data &&
+    typeof data.meta === 'object' &&
+    data.meta !== null &&
+    'content' in data.meta &&
+    typeof data.meta.content === 'object' &&
+    data.meta.content !== null &&
+    'title' in data.meta.content
+  );
+}


### PR DESCRIPTION
## Description

Output breadcrumb chain dynamically based on the api response.


~~I am adding a [fallback if terms in response is empty](https://github.com/CanadianClimateDataPortal/climatedata-wp-theme/pull/360/files#r2022160232). Needs double check. does not seem ideal. Since I am still in the grey about the whole data shape and flow of the app 🤷🏼, I am not sure if it is better to just render empty or the title as per the api. Since if the API response would be:~~

~~variable-datasets: {~~
  ~~terms: [{~~
    ~~term_id: 1,~~
    ~~title: {~~
      ~~en: "Historical Canadian Climate Normals",~~
      ~~fr: "Normales..."~~
    ~~}~~
  ~~}]~~
~~}~~
~~

~~then the code will pick that up and show. Of course it will be more clear to me after implementing the ticket #81992 where I will be dealing with all these variables directly.~~
~~Appreciate any insight.~~

@don-ew @mahieddineak , thanks for the insights, implemented all the comments.

**Here is how the app behaves now:**

**Initial load**: No title is set in the breadcrumbs and it shows empty.

![Screenshot 2025-04-05 at 6 43 22 PM](https://github.com/user-attachments/assets/add7c3d0-08ca-44d3-9511-d509d3f0aad4)

**Dataset selected**: Data set name sets in state and shows in the UI:

![image](https://github.com/user-attachments/assets/aba6eb4d-b3b2-4f7a-a659-b5466f6d8d42)

**Variable selected**: Same as data set. And the variable name shows in the UI.

![image](https://github.com/user-attachments/assets/f4ae8eb2-1a5d-4a2c-985b-1ae46897e24c)

**Locale support**: The breadcrumb supports locale. I have made some improvements for better detection of client locale with `navigator.language`

![Screenshot 2025-04-05 at 5 23 34 PM](https://github.com/user-attachments/assets/df94f1b4-850b-466d-ab45-651bcddc77ca)

Then:

![image](https://github.com/user-attachments/assets/cccac41f-b12a-4eb8-8406-609b6d768b47)

