### PR TITLE
CLIM-939: Docker registry cleanup: keep version tags

### DIFF
--- a/cicd/docker-registry-cleanup.py
+++ b/cicd/docker-registry-cleanup.py
@@ -1,9 +1,11 @@
 import argparse
 import requests
+import re
 from datetime import datetime
 from typing import NamedTuple, List
 
 reserved_tags = ["preprod", "uat", "qa"]
+version_pattern = re.compile(r"^v\d+\.\d+\.\d+$")
 
 
 class TagInfo(NamedTuple):
@@ -162,7 +164,7 @@ def filter_required_tags(tags: List[TagInfo]) -> List[TagInfo]:
     filtered_tags = []
 
     for tag_info in tags:
-        if tag_info.name in reserved_tags:
+        if tag_info.name in reserved_tags or version_pattern.match(tag_info.name):
             protected_digests.append(tag_info.digest)
 
     for tag_info in tags:


### PR DESCRIPTION
## Description

This PR modifies the image cleaning script so that it does not remove vX.Y.Z tags where X, Y and Z are numbers (ex: v2.0.14).

## Related ticket
CLIM-939