### PR TITLE
81992: Add necessary behaviour to the variable selection filters to refine the list of variables -- improvements

### DIFF
--- a/apps/src/Global.css
+++ b/apps/src/Global.css
@@ -6,11 +6,9 @@
 	font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
 	line-height: 1.5;
 	font-weight: 400;
-
 	color-scheme: light dark;
 	color: rgba(255, 255, 255, 0.87);
 	background-color: #242424;
-
 	font-synthesis: none;
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
@@ -69,6 +67,7 @@
 		--neutral-grey-medium: 0 0% 46.27%;
 		--neutral-grey-light: 0 0% 97.8%;
 	}
+
 	.dark {
 		--background: 0 0% 3.9%;
 		--foreground: 0 0% 98%;
@@ -111,6 +110,7 @@
 	* {
 		@apply border-border;
 	}
+
 	body {
 		@apply bg-background text-foreground font-["CDCSans"];
 	}
@@ -147,7 +147,6 @@
 }
 
 /* map search control override styles */
-
 .leaflet-container .leaflet-control,
 .leaflet-control-container > div {
 	z-index: 30;
@@ -251,4 +250,25 @@
 	fill: #18181b;
 	text-anchor: end;
 	dominant-baseline: middle;
+}
+
+/* Custom scrollbar styles for variables panel */
+@layer utilities {
+	.scrollbar-thin {
+		scrollbar-width: thin;
+		scrollbar-color: hsl(var(--cold-grey-004) / 0.5) transparent;
+	}
+
+	.scrollbar-thin::-webkit-scrollbar {
+		width: 4px;
+	}
+
+	.scrollbar-thin::-webkit-scrollbar-track {
+		background: transparent;
+	}
+
+	.scrollbar-thin::-webkit-scrollbar-thumb {
+		background-color: hsl(var(--cold-grey-004) / 0.5);
+		border-radius: 4px;
+	}
 }

--- a/apps/src/components/app-sidebar.tsx
+++ b/apps/src/components/app-sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useI18n } from '@wordpress/react-i18n';
 import { BadgeInfo, MessageCircleQuestion } from 'lucide-react';
 import { useMap } from '@/hooks/use-map';
@@ -55,6 +55,23 @@ export function AppSidebar() {
 	const { setExtendInfo } = useMap();
 	const dispatch = useAppDispatch();
 
+	// Update the selected variable when the climate variable changes
+	useEffect(() => {
+		if (climateVariable) {
+			const currentVarId = climateVariable.getId();
+
+			if (!selectedVariable || selectedVariable.id !== currentVarId) {
+				// Create a basic PostData object from the climate variable
+				const varData: PostData = {
+					id: currentVarId,
+					postId: climateVariable.toObject().postId || 0,
+					title: currentVarId, // @TODO: Update this after merging the breadcrumsb PR, as there we have the title in the map state
+				};
+				setSelectedVariable(varData);
+			}
+		}
+	}, [climateVariable, selectedVariable]);
+
 	const { __ } = useI18n();
 
 	const handleSelectVariable = (variable: PostData) => {
@@ -86,7 +103,7 @@ export function AppSidebar() {
 									<SidebarSeparator />
 
 									<VersionsDropdown />
-									{showThreshold && <ThresholdValuesDropdown/>}
+									{showThreshold && <ThresholdValuesDropdown />}
 									<SidebarSeparator />
 
 									<EmissionScenariosControl />

--- a/apps/src/components/sidebar-menu-items/datasets.tsx
+++ b/apps/src/components/sidebar-menu-items/datasets.tsx
@@ -110,8 +110,8 @@ const DatasetsPanel: React.FC<InteractivePanelProps<TaxonomyData | null>> = ({
 
 	return (
 		<SidebarPanel id={slug} className="w-96">
-			<Card>
-				<CardHeader className="p-4">
+			<Card className="h-full flex flex-col">
+				<CardHeader className="p-4 sticky top-0 bg-white z-10">
 					<CardTitle className="text-lg">
 						{__('Select a dataset')}
 					</CardTitle>
@@ -121,7 +121,7 @@ const DatasetsPanel: React.FC<InteractivePanelProps<TaxonomyData | null>> = ({
 						)}
 					</CardDescription>
 				</CardHeader>
-				<CardContent className="p-4 pt-0">
+				<CardContent className="p-4 pt-0 overflow-y-auto max-h-[calc(100vh-200px)] scrollbar-thin">
 					<Grid columns={1} className="gap-4">
 						{datasets.map((item) => (
 							<RadioCard

--- a/apps/src/components/sidebar-menu-items/datasets.tsx
+++ b/apps/src/components/sidebar-menu-items/datasets.tsx
@@ -29,7 +29,7 @@ import { useSidebar } from '@/hooks/use-sidebar';
 import { useLocale } from '@/hooks/use-locale';
 import { fetchTaxonomyData } from '@/services/services';
 import { InteractivePanelProps, TaxonomyData } from '@/types/types';
-import { setDataset } from '@/features/map/map-slice';
+import { setDataset, setVariableList, setVariableListLoading } from '@/features/map/map-slice';
 import { useClimateVariable } from '@/hooks/use-climate-variable';
 import { fetchPostsData } from '@/services/services';
 import { normalizePostData } from '@/lib/format';
@@ -80,10 +80,15 @@ const DatasetsPanel: React.FC<InteractivePanelProps<TaxonomyData | null>> = ({
 	const handleDatasetSelect = useCallback(async (dataset: TaxonomyData) => {
 		dispatch(setDataset(dataset));
 		onSelect(dataset);
+		dispatch(setVariableListLoading(true));
+		dispatch(setVariableList([]));
 
 		// Load the first variable for this dataset immediately
 		const data = await fetchPostsData('variables', 'map', dataset, {});
 		const variables = await normalizePostData(data, locale);
+
+		// Store the variables in Redux 
+		dispatch(setVariableList(variables));
 
 		// Select the first variable if available
 		if (variables.length > 0) {

--- a/apps/src/components/sidebar-menu-items/variables.tsx
+++ b/apps/src/components/sidebar-menu-items/variables.tsx
@@ -83,8 +83,8 @@ const VariablesPanel: React.FC<InteractivePanelProps<PostData>> = ({
 
 	return (
 		<SidebarPanel id={slug} className="w-[36rem]">
-			<Card>
-				<CardHeader className="p-4">
+			<Card className="border-0 shadow-none h-full flex flex-col">
+				<CardHeader className="p-4 sticky top-0 bg-white z-10">
 					<CardTitle className="text-lg">
 						{__('Select a variable')}
 					</CardTitle>
@@ -114,7 +114,7 @@ const VariablesPanel: React.FC<InteractivePanelProps<PostData>> = ({
 						/>
 					</Grid>
 				</CardHeader>
-				<CardContent className="p-4 pt-0">
+				<CardContent className="p-4 pt-0 overflow-y-auto max-h-[calc(100vh-200px)] scrollbar-thin">
 					<Grid columns={2} className="gap-4">
 						{dataset && <VariableRadioCards
 							dataset={dataset}

--- a/apps/src/components/ui/sidebar.tsx
+++ b/apps/src/components/ui/sidebar.tsx
@@ -290,7 +290,7 @@ const SidebarContent = React.forwardRef<
 			ref={ref}
 			data-sidebar="content"
 			className={cn(
-				'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+				'flex min-h-0 flex-1 flex-col gap-2 overflow-auto scrollbar-thin group-data-[collapsible=icon]:overflow-hidden',
 				className
 			)}
 			{...props}
@@ -505,7 +505,7 @@ const SidebarMenuAction = React.forwardRef<
 				'peer-data-[size=lg]/menu-button:top-2.5',
 				'group-data-[collapsible=icon]:hidden',
 				showOnHover &&
-					'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
+				'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
 				className
 			)}
 			{...props}

--- a/apps/src/components/variable-radio-cards.tsx
+++ b/apps/src/components/variable-radio-cards.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ExternalLink } from 'lucide-react';
 import { useI18n } from '@wordpress/react-i18n';
+import { useClimateVariable } from '@/hooks/use-climate-variable';
 
 import { RadioCard, RadioCardFooter } from '@/components/ui/radio-card';
 import Link from '@/components/ui/link';
@@ -18,26 +19,43 @@ const VariableRadioCards: React.FC<{
 	section: string;
 }> = ({ filterValues, selected, onSelect, dataset, section }) => {
 	const [variables, setVariables] = useState<PostData[]>([]);
+	const [isLoading, setIsLoading] = useState<boolean>(false);
 	const { __ } = useI18n();
 	const { locale } = useLocale();
+	const { selectClimateVariable } = useClimateVariable();
 
+	// Fetch variables when dataset or filters change
 	useEffect(() => {
+		if (!dataset) return;
+
+		setIsLoading(true);
+
 		(async () => {
-			if (!filterValues || !dataset) {
-				return;
+			const data = await fetchPostsData('variables', section, dataset, filterValues);
+			const normalizedData = await normalizePostData(data, locale);
+			setVariables(normalizedData);
+
+			//  On first load, select the first one
+			if (normalizedData.length > 0 && !selected) {
+				onSelect(normalizedData[0]);
+				selectClimateVariable(normalizedData[0]);
 			}
 
-			const data = await fetchPostsData('variables', section, dataset, filterValues);
-
-			// data from API has some complex structure, so we need to normalize it which will make it easier to work with
-			const normalizedData = await normalizePostData(data, locale);
-
-			setVariables(normalizedData);
+			setIsLoading(false);
 		})();
-	}, [dataset, filterValues, locale, section]);
+	}, [dataset, filterValues, locale, section, selected, onSelect, selectClimateVariable]);
 
-	if (!variables) {
-		return null;
+	const handleVariableSelect = (variable: PostData) => {
+		onSelect(variable);
+		selectClimateVariable(variable);
+	};
+
+	if (isLoading) {
+		return <div className="col-span-2 p-4 text-center">{__('Loading variables...')}</div>;
+	}
+
+	if (!variables || variables.length === 0) {
+		return <div className="col-span-2 p-4 text-center">{__('No variables found for the selected filters.')}</div>;
 	}
 
 	return (
@@ -50,8 +68,8 @@ const VariableRadioCards: React.FC<{
 					title={item.title}
 					description={item?.description}
 					thumbnail={item?.thumbnail}
-					selected={selected?.id === item.id}
-					onSelect={() => onSelect(item)}
+					selected={Boolean(selected && selected.id === item.id)}
+					onSelect={() => handleVariableSelect(item)}
 				>
 					{/* TODO: will need to correctly use the link value depending on the data structure when coming from the API */}
 					{item?.link?.url && (

--- a/apps/src/components/variable-radio-cards.tsx
+++ b/apps/src/components/variable-radio-cards.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { ExternalLink } from 'lucide-react';
 import { useI18n } from '@wordpress/react-i18n';
 import { useClimateVariable } from '@/hooks/use-climate-variable';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
 
 import { RadioCard, RadioCardFooter } from '@/components/ui/radio-card';
 import Link from '@/components/ui/link';
@@ -10,6 +11,7 @@ import { useLocale } from '@/hooks/use-locale';
 import { fetchPostsData } from '@/services/services';
 import { normalizePostData } from '@/lib/format';
 import { PostData, TaxonomyData } from '@/types/types';
+import { setVariableList, setVariableListLoading } from '@/features/map/map-slice';
 
 const VariableRadioCards: React.FC<{
 	filterValues: Record<string, string>;
@@ -18,49 +20,62 @@ const VariableRadioCards: React.FC<{
 	dataset: TaxonomyData;
 	section: string;
 }> = ({ filterValues, selected, onSelect, dataset, section }) => {
-	const [variables, setVariables] = useState<PostData[]>([]);
-	const [isLoading, setIsLoading] = useState<boolean>(false);
 	const { __ } = useI18n();
 	const { locale } = useLocale();
+	const dispatch = useAppDispatch();
 	const { selectClimateVariable } = useClimateVariable();
+	const { variableList, variableListLoading } = useAppSelector((state) => state.map);
 
 	// Fetch variables when dataset or filters change
 	useEffect(() => {
 		if (!dataset) return;
 
-		setIsLoading(true);
+		if (variableList.length === 0) {
+			dispatch(setVariableListLoading(true));
 
-		(async () => {
-			const data = await fetchPostsData('variables', section, dataset, filterValues);
-			const normalizedData = await normalizePostData(data, locale);
-			setVariables(normalizedData);
+			// Tracking if component is still mounted in this
+			let isMounted = true;
 
-			//  On first load, select the first one
-			if (normalizedData.length > 0 && !selected) {
-				onSelect(normalizedData[0]);
-				selectClimateVariable(normalizedData[0]);
-			}
+			(async () => {
+				const data = await fetchPostsData('variables', section, dataset, filterValues);
+				const normalizedData = await normalizePostData(data, locale);
 
-			setIsLoading(false);
-		})();
-	}, [dataset, filterValues, locale, section, selected, onSelect, selectClimateVariable]);
+				if (isMounted) {
+					// Storing the variables in Redux
+					dispatch(setVariableList(normalizedData));
+
+					if (normalizedData.length > 0 && !selected) {
+						onSelect(normalizedData[0]);
+						selectClimateVariable(normalizedData[0]);
+					}
+				}
+			})();
+
+			return () => {
+				isMounted = false;
+			};
+		} else if (variableList.length > 0 && !selected) {
+			onSelect(variableList[0]);
+			selectClimateVariable(variableList[0]);
+		}
+	}, [dataset, filterValues, locale, section, variableList, dispatch, onSelect, selectClimateVariable, selected]);
 
 	const handleVariableSelect = (variable: PostData) => {
 		onSelect(variable);
 		selectClimateVariable(variable);
 	};
 
-	if (isLoading) {
+	if (variableListLoading) {
 		return <div className="col-span-2 p-4 text-center">{__('Loading variables...')}</div>;
 	}
 
-	if (!variables || variables.length === 0) {
+	if (!variableList || variableList.length === 0) {
 		return <div className="col-span-2 p-4 text-center">{__('No variables found for the selected filters.')}</div>;
 	}
 
 	return (
 		<>
-			{variables.map((item, index) => (
+			{variableList.map((item, index) => (
 				<RadioCard
 					key={index}
 					value={item}

--- a/apps/src/context/climate-variable-provider.tsx
+++ b/apps/src/context/climate-variable-provider.tsx
@@ -76,6 +76,8 @@ export const ClimateVariableProvider: React.FC<{
 	 * is thrown.
 	 */
 	const climateVariable = useMemo(() => {
+		if (!climateVariableData) return null;
+		
 		const climateVariableClass =
 			CLIMATE_VARIABLE_CLASS_MAP[climateVariableData.class];
 		if (!climateVariableClass) {
@@ -247,6 +249,7 @@ export const ClimateVariableProvider: React.FC<{
 
 	const addSelectedPoints = useCallback(
 		(gridCoordinates: GridCoordinates) => {
+			if (!climateVariableData) return;
 			const { selectedPoints } = climateVariableData;
 			dispatch(
 				updateClimateVariable({
@@ -262,6 +265,7 @@ export const ClimateVariableProvider: React.FC<{
 
 	const removeSelectedPoint = useCallback(
 		(gid: number) => {
+			if (!climateVariableData) return;
 			const { [gid]: removed, ...rest } =
 				climateVariableData.selectedPoints ?? {};
 			console.log({ removed, rest });
@@ -275,12 +279,13 @@ export const ClimateVariableProvider: React.FC<{
 	);
 
 	const resetSelectedPoints = useCallback(() => {
+		if (!climateVariableData) return;
 		dispatch(
 			updateClimateVariable({
 				selectedPoints: {},
 			})
 		);
-	}, [dispatch]);
+	}, [dispatch, climateVariableData]);
 
 	const value: ClimateVariableContextType = {
 		climateVariable,

--- a/apps/src/features/map/map-slice.ts
+++ b/apps/src/features/map/map-slice.ts
@@ -27,7 +27,7 @@
  */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { MapState, MapLocation, WMSLegendData, TaxonomyData } from '@/types/types';
+import { MapState, MapLocation, WMSLegendData, TaxonomyData, PostData } from '@/types/types';
 import {
 	SLIDER_DEFAULT_YEAR_VALUE,
 	SLIDER_MAX_YEAR,
@@ -61,6 +61,8 @@ const initialState: MapState = {
 		labels: 1,
 	},
 	legendData: {},
+	variableList: [],
+	variableListLoading: false,
 };
 
 // Create the slice
@@ -70,6 +72,15 @@ const mapSlice = createSlice({
 	reducers: {
 		setDataset(state, action: PayloadAction<TaxonomyData | null>) {
 			state.dataset = action.payload ?? undefined;
+			// Reset variable list when dataset changes
+			state.variableList = [];
+		},
+		setVariableList(state, action: PayloadAction<PostData[]>) {
+			state.variableList = action.payload;
+			state.variableListLoading = false;
+		},
+		setVariableListLoading(state, action: PayloadAction<boolean>) {
+			state.variableListLoading = action.payload;
 		},
 		setVariable(state, action: PayloadAction<string>) {
 			state.variable = action.payload;
@@ -147,6 +158,8 @@ const mapSlice = createSlice({
 // Export actions
 export const {
 	setDataset,
+	setVariableList,
+	setVariableListLoading,
 	setVariable,
 	setDecade,
 	setEmissionScenario,

--- a/apps/src/store/climate-variable-slice.ts
+++ b/apps/src/store/climate-variable-slice.ts
@@ -1,13 +1,12 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { ClimateVariables } from "@/config/climate-variables.config";
 import { ClimateVariableConfigInterface } from "@/types/climate-variable-interface";
 
 interface ClimateVariableStateInterface {
-	data: ClimateVariableConfigInterface;
+	data: ClimateVariableConfigInterface | null;
 }
 
 const initialState: ClimateVariableStateInterface = {
-	data: ClimateVariables[0],
+	data: null,
 }
 
 const climateVariableSlice = createSlice({
@@ -18,12 +17,16 @@ const climateVariableSlice = createSlice({
 			state.data = action.payload;
 		},
 		updateClimateVariable: (state, action) => {
+			if (!state.data) return;
+			
 			state.data = {
 				...state.data,
 				...action.payload
 			};
 		},
 		updateClimateVariableAnalysisFieldValue: (state, action) => {
+			if (!state.data || !state.data.analysisFieldValues) return;
+			
 			const {key, value} = action.payload;
 
 			state.data = {

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -204,6 +204,8 @@ export interface MapState {
 		mapData: number;
 		labels: number;
 	};
+	variableList: PostData[];
+	variableListLoading: boolean;
 }
 
 /**


### PR DESCRIPTION
## Description

- All datasets are loading on first load instead of getting the list of dataset every time the dataset panel is opened.
The default variable loaded is the first variable found in that dataset.
- The variable panel can now be scrolled when there are a lot of variables.
- Correct scroll effect for the datasets panel similar to the variables panel
- Correct scroll colour for the sidebar content component so if it scrolls just in case

Variables panel:
![image](https://github.com/user-attachments/assets/3fcb5493-3f43-4744-a4d2-8d06a12c249f)

Dataset panel and Sidebar:
![image](https://github.com/user-attachments/assets/2104f34f-21e2-4d10-a4a0-dbf158c5dace)

---

New comments by @don-ew
1. When I'm switching from one variable to another, the variable list refreshes again even when there are no changes in the dataset or filters. Is there a way to not have the list refresh again?

2. On first load, the first variable config is being loaded, which was initially done for testing purposes. Can you please update https://github.com/CanadianClimateDataPortal/climatedata-wp-theme/blob/dd950a269ac1d1e095c40629062e71675fee1773/apps/src/store/climate-variable-slice.ts#L9-L8 as well such that the initialState is empty?

**Changes:**

1. Fix: Cache variable list to prevent reloading on panel open
The variable list was reloading every time the variables panel was opened.
I had to lift up the variable data to Redux, and by implementing caching for variables, similar to the approach used for datasets, but reloading if a new dataset is selected.

2. Now state is empty on init, and then will populate with Variable data from the selected dataset
![image](https://github.com/user-attachments/assets/609c6cf9-b51d-47a9-bce6-786a5cbe7507)


## Related ticket

[81993](https://rm.ewdev.ca/issues/81993)

> Make sure to read the *Pull requests* section in CONTRIBUTING.md.
>
> Main points:
>
> * The assigned reviewer(s) must always *submit* a review (not simply add a
    >   comment).
>
> * If the PR is "Approved", the creator of the PR must then:
    >   * Implement the changes in the reviewer's comments, if applicable, and mark
          >     them as "Resolved".
>   * Squash and merge the branch.
>   * Delete the branch.
>
> * If the PR is "Request Changes", the creator of the PR must then:
    >   * Update the code as requested.
>   * Re-request a review from the reviewer.
>   * NOT mark the comments as "Resolved", the reviewer will.
>
> (You can keep or remove this block, as you wish.)
