### PR TITLE
EW 84452: Add dataset type

### DIFF
--- a/fw-child/acf-json/group_677ff329db550.json
+++ b/fw-child/acf-json/group_677ff329db550.json
@@ -134,6 +134,51 @@
             },
             "return_format": "array",
             "allow_in_bindings": 0
+        },
+        {
+            "key": "field_67f970df2ab71",
+            "label": "",
+            "name": "",
+            "aria-label": "",
+            "type": "tab",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "placement": "top",
+            "endpoint": 1,
+            "selected": 0
+        },
+        {
+            "key": "field_67f96f16538be",
+            "label": "Dataset Type",
+            "name": "dataset_type",
+            "aria-label": "",
+            "type": "select",
+            "instructions": "The dataset type is used in the internal logic of the map and download apps.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "projection": "Projection",
+                "ahccd": "AHCCD"
+            },
+            "default_value": false,
+            "return_format": "value",
+            "multiple": 0,
+            "allow_null": 1,
+            "allow_in_bindings": 0,
+            "ui": 0,
+            "ajax": 0,
+            "placeholder": ""
         }
     ],
     "location": [
@@ -154,5 +199,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1740090740
+    "modified": 1744400632
 }

--- a/fw-child/resources/functions/rest-v3/datasets-list.php
+++ b/fw-child/resources/functions/rest-v3/datasets-list.php
@@ -117,7 +117,10 @@ function cdc_rest_v3_get_datasets_list( $request ) {
 			}
 
 			// Add dataset type if set.
-			if ( ! empty( $dataset_type ) ) {
+			if (
+				! empty( $dataset_type ) &&
+				in_array( $dataset_type, array( 'projection', 'ahccd' ), true )
+			) {
 				$dataset['dataset_type'] = $dataset_type;
 			}
 

--- a/fw-child/resources/functions/rest-v3/datasets-list.php
+++ b/fw-child/resources/functions/rest-v3/datasets-list.php
@@ -75,6 +75,7 @@ function cdc_rest_v3_get_datasets_list( $request ) {
 			$card_description_fr = get_field( 'card_description_fr', 'term_' . $term_id );
 			$card_link           = get_field( 'card_link', 'term_' . $term_id );
 			$card_link_fr        = get_field( 'card_link_fr', 'term_' . $term_id );
+			$dataset_type        = get_field( 'dataset_type', 'term_' . $term_id );
 
 			// Build dataset array.
 			$dataset = array(
@@ -113,6 +114,11 @@ function cdc_rest_v3_get_datasets_list( $request ) {
 			// Add card object if it has content.
 			if ( ! empty( $card ) ) {
 				$dataset['card'] = $card;
+			}
+
+			// Add dataset type if set.
+			if ( ! empty( $dataset_type ) ) {
+				$dataset['dataset_type'] = $dataset_type;
 			}
 
 			$datasets[] = $dataset;


### PR DESCRIPTION
## Description

Create a new ACF select field on the variable-dataset taxonomy to define the dataset type. This type will be used to determine variable specifications in applications.

Dataset Type options:
* Projection
* AHCCD

A dataset parameter was add to the datasets list endpoint.

## Related ticket

https://rm.ewdev.ca/issues/84452
