### PR TITLE
refs: #81996: fix scenario comparison feature, remove unused scenario options from map-slice

### DIFF
--- a/apps/src/components/map-layers/interactive-regions-layer.tsx
+++ b/apps/src/components/map-layers/interactive-regions-layer.tsx
@@ -22,11 +22,12 @@ import { getDefaultFrequency } from "@/lib/utils";
 import SectionContext from "@/context/section-provider";
 
 interface InteractiveRegionsLayerProps {
+	scenario?: string | null | undefined;
 	onLocationModalOpen: (content: React.ReactNode) => void;
 	onLocationModalClose: () => void;
 }
 
-const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({ onLocationModalOpen, onLocationModalClose }) => {
+const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({ scenario, onLocationModalOpen, onLocationModalClose }) => {
 	const [layerData, setLayerData] = useState<Record<number, number> | null>(
 		null
 	);
@@ -243,7 +244,7 @@ const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({ onLoc
 					decade: startYear,
 					frequency,
 					interactiveRegion,
-					emissionScenario: climateVariable?.getScenario() ?? '',
+					emissionScenario: scenario ?? '',
 					decimals: 1,
 				});
 

--- a/apps/src/components/raster-map-container.tsx
+++ b/apps/src/components/raster-map-container.tsx
@@ -19,17 +19,20 @@ import {
 	DEFAULT_MAX_ZOOM,
 	GEOSERVER_BASE_URL,
 } from '@/lib/constants';
-import { getDefaultFrequency, getFrequencyCode } from "@/lib/utils";
+import { cn, getDefaultFrequency, getFrequencyCode } from "@/lib/utils";
 import SectionContext from "@/context/section-provider";
 import { FrequencyType } from "@/types/climate-variable-interface";
+import appConfig from "@/config/app.config";
 
 /**
  * Renders a Leaflet map, including custom panes and tile layers.
  */
 export default function RasterMapContainer({
+	scenario,
 	onMapReady,
 	onUnmount,
 }: {
+	scenario: string | null | undefined;
 	onMapReady: (map: L.Map) => void;
 	onUnmount?: () => void;
 }) {
@@ -44,13 +47,14 @@ export default function RasterMapContainer({
 
 	const section = useContext(SectionContext);
 
+	const scenarioLabel = appConfig.scenarios.find(item => item.value === scenario)?.label ?? scenario;
+
 	const layerValue: string = useMemo(() => {
 		let version;
 		if (climateVariable) {
 			version = climateVariable.getVersion() === 'cmip5' ? '' : climateVariable.getVersion();
 		}
 
-		const scenario = climateVariable?.getScenario();
 		const threshold = climateVariable?.getThreshold();
 
 		let frequency = climateVariable?.getFrequency() ?? null;
@@ -121,12 +125,25 @@ export default function RasterMapContainer({
 				{locationModalContent}
 			</LocationModal>
 
-			<InteractiveRegionsLayer onLocationModalOpen={handleLocationModalOpen} onLocationModalClose={handleLocationModalClose} />
+			<InteractiveRegionsLayer
+				scenario={scenario}
+				onLocationModalOpen={handleLocationModalOpen}
+				onLocationModalClose={handleLocationModalClose}
+			/>
 
 			<TileLayer
 				attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 				url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
 			/>
+
+			{/* show current scenario label */}
+			<div className={cn(
+				'absolute bottom-6 left-1/2 transform -translate-x-1/2 z-20',
+				'text-sm text-zinc-900 font-normal leading-5',
+				'bg-neutral-grey-light border border-cold-grey-4 shadow-md rounded-xl px-3.5 py-1.5',
+			)}>
+				{scenarioLabel}
+			</div>
 
 			{/* Basemap TileLayer */}
 			<TileLayer

--- a/apps/src/components/raster-map.tsx
+++ b/apps/src/components/raster-map.tsx
@@ -6,25 +6,19 @@ import RasterMapContainer from '@/components/raster-map-container';
 
 // other
 import { cn } from '@/lib/utils';
-import { useAppSelector } from '@/app/hooks';
 import { useMap } from '@/hooks/use-map';
+import { useClimateVariable } from "@/hooks/use-climate-variable";
 
 /**
  * Renders a Leaflet map, including custom panes and tile layers.
  */
 export default function RasterMap(): React.ReactElement {
-	const { emissionScenarioCompare, emissionScenarioCompareTo } =
-		useAppSelector((state) => state.map);
-
 	const { setMap } = useMap();
+	const { climateVariable } = useClimateVariable();
 
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const mapRef = useRef<L.Map | null>(null);
 	const comparisonMapRef = useRef<L.Map | null>(null);
-
-	// show the comparison map if compare checkbox is checked and there is a compare-to scenario
-	const showComparisonMap =
-		emissionScenarioCompare && !!emissionScenarioCompareTo;
 
 	// helper sync/unsync methods for convenience
 	const syncMaps = () => {
@@ -50,13 +44,14 @@ export default function RasterMap(): React.ReactElement {
 		}
 	};
 
+	console.log('compare to:', climateVariable?.getScenarioCompared())
 	return (
 		<div
 			ref={wrapperRef}
 			className={cn(
 				'map-wrapper',
 				'grid gap-4 h-full z-30',
-				showComparisonMap ? 'grid-cols-2' : 'grid-cols-1'
+				climateVariable?.getScenarioCompared() ? 'grid-cols-2' : 'grid-cols-1'
 			)}
 		>
 			<RasterMapContainer
@@ -66,7 +61,7 @@ export default function RasterMap(): React.ReactElement {
 				}}
 				onUnmount={() => (mapRef.current = null)}
 			/>
-			{showComparisonMap && (
+			{climateVariable?.getScenarioCompared() && (
 				<RasterMapContainer
 					onMapReady={(map: L.Map) => {
 						comparisonMapRef.current = map;

--- a/apps/src/components/raster-map.tsx
+++ b/apps/src/components/raster-map.tsx
@@ -44,25 +44,28 @@ export default function RasterMap(): React.ReactElement {
 		}
 	};
 
-	console.log('compare to:', climateVariable?.getScenarioCompared())
+	const showComparisonMap = climateVariable?.getScenarioCompare() && climateVariable?.getScenarioCompareTo();
+
 	return (
 		<div
 			ref={wrapperRef}
 			className={cn(
 				'map-wrapper',
 				'grid gap-4 h-full z-30',
-				climateVariable?.getScenarioCompared() ? 'grid-cols-2' : 'grid-cols-1'
+				showComparisonMap ? 'grid-cols-2' : 'grid-cols-1'
 			)}
 		>
 			<RasterMapContainer
+				scenario={climateVariable?.getScenario()}
 				onMapReady={(map: L.Map) => {
 					mapRef.current = map;
 					setMap(map);
 				}}
 				onUnmount={() => (mapRef.current = null)}
 			/>
-			{climateVariable?.getScenarioCompared() && (
+			{showComparisonMap && (
 				<RasterMapContainer
+					scenario={climateVariable?.getScenarioCompareTo()}
 					onMapReady={(map: L.Map) => {
 						comparisonMapRef.current = map;
 						syncMaps(); // sync once the comparison map is ready

--- a/apps/src/components/sidebar-menu-items/emission-scenarios-control.tsx
+++ b/apps/src/components/sidebar-menu-items/emission-scenarios-control.tsx
@@ -4,7 +4,7 @@
  * A dropdown component that allows the user to select an emission scenario and compare it
  * with another from a secondary dropdown.
  */
-import React, { useState } from 'react';
+import React from 'react';
 import { useI18n } from '@wordpress/react-i18n';
 
 import { useClimateVariable } from "@/hooks/use-climate-variable";
@@ -18,19 +18,8 @@ import Dropdown from '@/components/ui/dropdown';
 import appConfig from "@/config/app.config";
 
 const EmissionScenariosControl: React.FC = () => {
-	const [compareScenarios, setCompareScenarios] = useState<boolean>(false);
 	const { __ } = useI18n();
-	const { climateVariable, setScenario, setScenarioCompared } = useClimateVariable();
-
-	const toggleCompareScenarios = () => {
-		setCompareScenarios(prev => {
-			const newCompare = !prev;
-			if (!newCompare) {
-				setScenarioCompared(null);
-			}
-			return newCompare;
-		});
-	};
+	const { climateVariable, setScenario, setScenarioCompare, setScenarioCompareTo } = useClimateVariable();
 
 	const Tooltip = () => (
 		<div className="text-sm text-gray-500">
@@ -49,7 +38,9 @@ const EmissionScenariosControl: React.FC = () => {
 					label={__('Emissions Scenarios')}
 					tooltip={<Tooltip />}
 					placeholder={__('Select an option')}
-					options={scenarioOptions}
+					options={scenarioOptions.filter(
+						(option) => option.value !== climateVariable?.getScenarioCompareTo()
+					) ?? []}
 					value={climateVariable?.getScenario() ?? undefined}
 					onChange={setScenario}
 				/>
@@ -58,8 +49,8 @@ const EmissionScenariosControl: React.FC = () => {
 					<Checkbox
 						id="compare-scenarios"
 						className="text-brand-red"
-						checked={compareScenarios}
-						onCheckedChange={toggleCompareScenarios}
+						checked={climateVariable?.getScenarioCompare() ?? false}
+						onCheckedChange={setScenarioCompare}
 					/>
 					<label
 						htmlFor="compare-scenarios"
@@ -69,13 +60,13 @@ const EmissionScenariosControl: React.FC = () => {
 					</label>
 				</div>
 
-				{compareScenarios && (
+				{climateVariable?.getScenarioCompare() && (
 					<Dropdown
 						options={scenarioOptions.filter(
 							(option) => option.value !== climateVariable?.getScenario()
 						) ?? []}
-						value={climateVariable?.getScenarioCompared() ?? undefined}
-						onChange={setScenarioCompared}
+						value={climateVariable?.getScenarioCompareTo() ?? undefined}
+						onChange={setScenarioCompareTo}
 					/>
 				)}
 			</div>

--- a/apps/src/components/sidebar-menu-items/emission-scenarios-control.tsx
+++ b/apps/src/components/sidebar-menu-items/emission-scenarios-control.tsx
@@ -4,7 +4,7 @@
  * A dropdown component that allows the user to select an emission scenario and compare it
  * with another from a secondary dropdown.
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { useI18n } from '@wordpress/react-i18n';
 
 import { useClimateVariable } from "@/hooks/use-climate-variable";
@@ -15,29 +15,21 @@ import { Checkbox } from '@/components/ui/checkbox';
 import Dropdown from '@/components/ui/dropdown';
 
 // other
-import { useAppDispatch, useAppSelector } from '@/app/hooks';
-import {
-	setEmissionScenarioCompare,
-	setEmissionScenarioCompareTo,
-} from '@/features/map/map-slice';
 import appConfig from "@/config/app.config";
 
 const EmissionScenariosControl: React.FC = () => {
+	const [compareScenarios, setCompareScenarios] = useState<boolean>(false);
 	const { __ } = useI18n();
-	const dispatch = useAppDispatch();
-	const { climateVariable, setScenario } = useClimateVariable();
+	const { climateVariable, setScenario, setScenarioCompared } = useClimateVariable();
 
-	const {
-		emissionScenarioCompare,
-		emissionScenarioCompareTo,
-	} = useAppSelector((state) => state.map);
-
-	const handleEmissionScenarioCompareChange = (checked: boolean) => {
-		dispatch(setEmissionScenarioCompare(checked));
-	};
-
-	const handleEmissionScenarioCompareToChange = (value: string) => {
-		dispatch(setEmissionScenarioCompareTo(value));
+	const toggleCompareScenarios = () => {
+		setCompareScenarios(prev => {
+			const newCompare = !prev;
+			if (!newCompare) {
+				setScenarioCompared(null);
+			}
+			return newCompare;
+		});
 	};
 
 	const Tooltip = () => (
@@ -66,8 +58,8 @@ const EmissionScenariosControl: React.FC = () => {
 					<Checkbox
 						id="compare-scenarios"
 						className="text-brand-red"
-						checked={emissionScenarioCompare}
-						onCheckedChange={handleEmissionScenarioCompareChange}
+						checked={compareScenarios}
+						onCheckedChange={toggleCompareScenarios}
 					/>
 					<label
 						htmlFor="compare-scenarios"
@@ -77,13 +69,13 @@ const EmissionScenariosControl: React.FC = () => {
 					</label>
 				</div>
 
-				{emissionScenarioCompare && (
+				{compareScenarios && (
 					<Dropdown
 						options={scenarioOptions.filter(
 							(option) => option.value !== climateVariable?.getScenario()
 						) ?? []}
-						value={emissionScenarioCompareTo}
-						onChange={handleEmissionScenarioCompareToChange}
+						value={climateVariable?.getScenarioCompared() ?? undefined}
+						onChange={setScenarioCompared}
 					/>
 				)}
 			</div>

--- a/apps/src/context/climate-variable-provider.tsx
+++ b/apps/src/context/climate-variable-provider.tsx
@@ -26,7 +26,8 @@ export type ClimateVariableContextType = {
 	selectClimateVariable: (variable: PostData) => void;
 	setVersion: (version: string) => void;
 	setScenario: (scenario: string) => void;
-	setScenarioCompared: (scenarioCompared: string) => void;
+	setScenarioCompare: (scenarioCompare: boolean) => void;
+	setScenarioCompareTo: (scenarioCompareTo: string | null) => void;
 	setAnalyzeScenarios: (analyzeScenarios: string[]) => void;
 	setThreshold: (threshold: string) => void;
 	setInteractiveRegion: (interactiveRegion: InteractiveRegionOption) => void;
@@ -80,7 +81,7 @@ export const ClimateVariableProvider: React.FC<{
 	 */
 	const climateVariable = useMemo(() => {
 		if (!climateVariableData) return null;
-		
+
 		const climateVariableClass =
 			CLIMATE_VARIABLE_CLASS_MAP[climateVariableData.class];
 		if (!climateVariableClass) {
@@ -161,11 +162,22 @@ export const ClimateVariableProvider: React.FC<{
 		[dispatch]
 	);
 
-	const setScenarioCompared = useCallback(
-		(scenarioCompared: string | null) => {
+	const setScenarioCompare = useCallback(
+		(scenarioCompare: boolean) => {
 			dispatch(
 				updateClimateVariable({
-					scenarioCompared,
+					scenarioCompare,
+				})
+			);
+		},
+		[dispatch]
+	);
+
+	const setScenarioCompareTo = useCallback(
+		(scenarioCompareTo: string | null) => {
+			dispatch(
+				updateClimateVariable({
+					scenarioCompareTo,
 				})
 			);
 		},
@@ -328,7 +340,8 @@ export const ClimateVariableProvider: React.FC<{
 		selectClimateVariable,
 		setVersion,
 		setScenario,
-		setScenarioCompared,
+		setScenarioCompare,
+		setScenarioCompareTo,
 		setAnalyzeScenarios,
 		setThreshold,
 		setInteractiveRegion,

--- a/apps/src/context/climate-variable-provider.tsx
+++ b/apps/src/context/climate-variable-provider.tsx
@@ -26,6 +26,7 @@ export type ClimateVariableContextType = {
 	selectClimateVariable: (variable: PostData) => void;
 	setVersion: (version: string) => void;
 	setScenario: (scenario: string) => void;
+	setScenarioCompared: (scenarioCompared: string) => void;
 	setAnalyzeScenarios: (analyzeScenarios: string[]) => void;
 	setThreshold: (threshold: string) => void;
 	setInteractiveRegion: (interactiveRegion: InteractiveRegionOption) => void;
@@ -154,6 +155,17 @@ export const ClimateVariableProvider: React.FC<{
 			dispatch(
 				updateClimateVariable({
 					scenario,
+				})
+			);
+		},
+		[dispatch]
+	);
+
+	const setScenarioCompared = useCallback(
+		(scenarioCompared: string | null) => {
+			dispatch(
+				updateClimateVariable({
+					scenarioCompared,
 				})
 			);
 		},
@@ -316,6 +328,7 @@ export const ClimateVariableProvider: React.FC<{
 		selectClimateVariable,
 		setVersion,
 		setScenario,
+		setScenarioCompared,
 		setAnalyzeScenarios,
 		setThreshold,
 		setInteractiveRegion,

--- a/apps/src/features/map/map-slice.ts
+++ b/apps/src/features/map/map-slice.ts
@@ -45,9 +45,6 @@ const defaultTimePeriodEnd = Math.min(
 const initialState: MapState = {
 	variable: 'tx_max',
 	decade: '2040',
-	emissionScenario: 'high',
-	emissionScenarioCompare: false,
-	emissionScenarioCompareTo: '',
 	thresholdValue: 5,
 	interactiveRegion: REGION_GRID,
 	frequency: 'ann',

--- a/apps/src/features/map/map-slice.ts
+++ b/apps/src/features/map/map-slice.ts
@@ -88,23 +88,11 @@ const mapSlice = createSlice({
 		setDecade(state, action: PayloadAction<string>) {
 			state.decade = action.payload;
 		},
-		setEmissionScenario(state, action: PayloadAction<string>) {
-			state.emissionScenario = action.payload;
-		},
-		setEmissionScenarioCompare(state, action: PayloadAction<boolean>) {
-			state.emissionScenarioCompare = action.payload;
-		},
-		setEmissionScenarioCompareTo(state, action: PayloadAction<string>) {
-			state.emissionScenarioCompareTo = action.payload;
-		},
 		setThresholdValue(state, action: PayloadAction<number>) {
 			state.thresholdValue = action.payload;
 		},
 		setInteractiveRegion(state, action: PayloadAction<string>) {
 			state.interactiveRegion = action.payload;
-		},
-		setFrequency(state, action: PayloadAction<string>) {
-			state.frequency = action.payload;
 		},
 		setTimePeriodEnd(state, action: PayloadAction<number[]>) {
 			state.timePeriodEnd = action.payload;
@@ -162,12 +150,8 @@ export const {
 	setVariableListLoading,
 	setVariable,
 	setDecade,
-	setEmissionScenario,
-	setEmissionScenarioCompare,
-	setEmissionScenarioCompareTo,
 	setThresholdValue,
 	setInteractiveRegion,
-	setFrequency,
 	setTimePeriodEnd,
 	addRecentLocation,
 	deleteLocation,

--- a/apps/src/lib/climate-variable-base.tsx
+++ b/apps/src/lib/climate-variable-base.tsx
@@ -92,15 +92,17 @@ class ClimateVariableBase implements ClimateVariableInterface {
 		return this.getScenarios()[0] || null;
 	}
 
-	getScenarioCompared(): string | null {
-		// Return the scenario to be compared against. Check if it belongs to the
-		// current version and is not the same as the current scenario.
-		// Otherwise, return null, because it will mean there is no comparison being made
-		// and the comparison map should not be displayed.
-		const currentScenario = this._config.scenario;
-		const scenarioCompared = this._config.scenarioCompared;
-		if (scenarioCompared && this.getScenarios().includes(scenarioCompared) && scenarioCompared !== currentScenario) {
-			return scenarioCompared;
+	getScenarioCompare(): boolean {
+		// Return if scenario comparison is checked or not.
+		return this._config.scenarioCompare ?? false;
+	}
+
+	getScenarioCompareTo(): string | null {
+		// Check if the scenarioCompareTo actually belongs to the current version
+		// If not, return null, as we don't want this to be the same as the current scenario.
+		const scenarioCompareTo = this._config.scenarioCompareTo;
+		if (scenarioCompareTo && this.getScenarios().includes(scenarioCompareTo)) {
+			return scenarioCompareTo;
 		}
 		return null;
 	}

--- a/apps/src/lib/climate-variable-base.tsx
+++ b/apps/src/lib/climate-variable-base.tsx
@@ -92,6 +92,19 @@ class ClimateVariableBase implements ClimateVariableInterface {
 		return this.getScenarios()[0] || null;
 	}
 
+	getScenarioCompared(): string | null {
+		// Return the scenario to be compared against. Check if it belongs to the
+		// current version and is not the same as the current scenario.
+		// Otherwise, return null, because it will mean there is no comparison being made
+		// and the comparison map should not be displayed.
+		const currentScenario = this._config.scenario;
+		const scenarioCompared = this._config.scenarioCompared;
+		if (scenarioCompared && this.getScenarios().includes(scenarioCompared) && scenarioCompared !== currentScenario) {
+			return scenarioCompared;
+		}
+		return null;
+	}
+
 	getAnalyzeScenarios(): string[] {
 		return this._config.analyzeScenarios ?? [];
 	}

--- a/apps/src/types/climate-variable-interface.ts
+++ b/apps/src/types/climate-variable-interface.ts
@@ -170,6 +170,9 @@ export interface ClimateVariableConfigInterface {
 	/** Selected scenario value */
 	scenario?: string | null;
 
+	/** Scenario to compare against `scenario` */
+	scenarioCompared?: string | null;
+
 	/** Selected scenarios for analysis */
 	analyzeScenarios?: string[];
 
@@ -283,6 +286,8 @@ export interface ClimateVariableInterface {
 	getScenarios(): string[];
 
 	getScenario(): string | null;
+
+	getScenarioCompared(): string | null;
 
 	getAnalyzeScenarios(): string[];
 

--- a/apps/src/types/climate-variable-interface.ts
+++ b/apps/src/types/climate-variable-interface.ts
@@ -170,8 +170,11 @@ export interface ClimateVariableConfigInterface {
 	/** Selected scenario value */
 	scenario?: string | null;
 
+	/** Compare scenarios flag */
+	scenarioCompare?: boolean;
+
 	/** Scenario to compare against `scenario` */
-	scenarioCompared?: string | null;
+	scenarioCompareTo?: string | null;
 
 	/** Selected scenarios for analysis */
 	analyzeScenarios?: string[];
@@ -287,7 +290,9 @@ export interface ClimateVariableInterface {
 
 	getScenario(): string | null;
 
-	getScenarioCompared(): string | null;
+	getScenarioCompare(): boolean;
+
+	getScenarioCompareTo(): string | null;
 
 	getAnalyzeScenarios(): string[];
 

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -168,9 +168,6 @@ export type SliderLabelsMap = {
  * Represents the map state in redux store.
  */
 export interface MapState {
-	emissionScenario: string;
-	emissionScenarioCompare: boolean;
-	emissionScenarioCompareTo: string;
 	interactiveRegion: string;
 	thresholdValue: number;
 	frequency: string;


### PR DESCRIPTION
## Description

This PR includes the following missing emission scenario features:

- Use correct scenario data for rendering the map
- Add current scenario label at the bottom of the map
- Fix comparison map
- Make sure the same scenario does not appear in both scenario dropdowns when  comparing

Also, old logic for emission scenarios was removed in favor of new class structure.

## Related ticket
