### PR TITLE
refs #0000: missing definition for label_en variable.

### DIFF
--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -536,6 +536,7 @@ export interface MapFeatureProps {
 	latlng: L.LatLng;
 	layer: {
 		properties: {
+			label_en?: string;
 			gid?: number;
 			id?: number;
 		};
@@ -616,6 +617,6 @@ export interface MapInfoData {
  */
 export interface VariableFilterCountProps {
     filteredCount: number;
-    totalCount: number; 
+    totalCount: number;
     className?: string;
 }


### PR DESCRIPTION
## Description

Fix a bad merge conflict error. This add the missing type for layer_properties.label_en.