### PR TITLE
Reverted default date value on getDateRange() method.

### DIFF
--- a/apps/src/lib/climate-variable-base.tsx
+++ b/apps/src/lib/climate-variable-base.tsx
@@ -201,8 +201,8 @@ class ClimateVariableBase implements ClimateVariableInterface {
 
 	getDateRange(): string[] | null {
 		return this._config.dateRange ?? [
-			"",
-			"",
+			"2040",
+			"2070",
 		];
 	}
 


### PR DESCRIPTION
## Description
Reverted default date value on getDateRange() method.

## Related ticket

[(If a ticket in your task manager is linked to this PR, replace this paragraph
with the URL to the ticket. If not applicable, you can remove this whole
section.)](https://rm.ewdev.ca/issues/85611)