### PR TITLE
Refs #78543, Refs #78545, Refs #82420

### DIFF
--- a/apps/src/Global.css
+++ b/apps/src/Global.css
@@ -289,10 +289,3 @@
 		transform: scale(1);
 	}
 }
-
-@media (max-width: 639px) {
-	/* Mobile-specific styles go here */
-	.breadcrumb .breadcrumb-item {
-		display: none;
-	}
-}

--- a/apps/src/Global.css
+++ b/apps/src/Global.css
@@ -289,3 +289,10 @@
 		transform: scale(1);
 	}
 }
+
+@media (max-width: 639px) {
+	/* Mobile-specific styles go here */
+	.breadcrumb .breadcrumb-item {
+		display: none;
+	}
+}

--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -45,7 +45,7 @@ const MapHeader: React.FC<MapInfoProps> = ({ data }): React.ReactElement => {
 			setPanelProps({
 				direction: 'right',
 				position: {
-					top: ref.current?.getBoundingClientRect().bottom || 0,
+					top: ref.current?.getBoundingClientRect().top || 0,
 				},
 			});
 		}
@@ -132,13 +132,13 @@ const Breadcrumbs: React.FC<{ onClick: () => void }> = ({
 	}, [climateVariable]);
 
 	return (
-		<div className="flex items-center gap-2">
-			{datasetName && <span>{datasetName}</span>}
-			{datasetName && variableTitle && <span>/</span>}
+		<div className="flex items-center gap-2 breadcrumb">
+			{datasetName && <span className='breadcrumb-item'>{datasetName}</span>}
+			{datasetName && variableTitle && <span className='breadcrumb-item breadcrumb-separator'>/</span>}
 			{variableTitle && (
 				<Button
 					variant="ghost"
-					className="text-md text-cdc-black hover:text-dark-purple hover:bg-transparent p-0 h-auto"
+					className="breadcrumb-button text-md text-cdc-black hover:text-dark-purple hover:bg-transparent p-0 h-auto"
 					onClick={onClick}
 					aria-label={__('View details')}
 				>

--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -133,8 +133,8 @@ const Breadcrumbs: React.FC<{ onClick: () => void }> = ({
 
 	return (
 		<div className="flex items-center gap-2 breadcrumb">
-			{datasetName && <span className='breadcrumb-item'>{datasetName}</span>}
-			{datasetName && variableTitle && <span className='breadcrumb-item breadcrumb-separator'>/</span>}
+			{datasetName && <span className='hidden md:inline'>{datasetName}</span>}
+			{datasetName && variableTitle && <span className='hidden md:inline'>/</span>}
 			{variableTitle && (
 				<Button
 					variant="ghost"

--- a/apps/src/components/map-layers/map-legend.tsx
+++ b/apps/src/components/map-layers/map-legend.tsx
@@ -45,7 +45,7 @@ const MapLegend: React.FC<{ url: string }> = ({ url }) => {
 		legend.onAdd = () => {
 			const container = L.DomUtil.create(
 				'div',
-				'legend-wrapper top-24 right-5 m-0 !mt-1.5 z-30'
+				'legend-wrapper top-[9rem] md:top-24 right-5 m-0 !mt-1.5 z-30'
 			);
 			const root = createRoot(container);
 

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -155,6 +155,7 @@ export default function SearchControl({
 		const searchControl = new L.Control.Search({
 			url: LOCATION_SEARCH_ENDPOINT,
 			propertyLoc: ['lat', 'lon'],
+			autoResize: false,
 			collapsed: false,
 			autoCollapse: false,
 			autoType: false,
@@ -208,8 +209,24 @@ export default function SearchControl({
 			}
 		});
 
+		// Dynamically set the input size attribute based on screen width.
+		// If the screen is less than 520px wide, set the size to 27 (smaller input).
+		// Otherwise, set the size to 48 (default for larger screens).
+		function updateInputSize() {
+			if (searchInput) {
+				if (window.innerWidth < 520) {
+					searchInput.setAttribute('size', '27');
+				} else {
+					searchInput.setAttribute('size', '48'); // Or set to your default
+				}
+			}
+		}
+		updateInputSize();
+		window.addEventListener('resize', updateInputSize);
+
 		return () => {
 			map.removeControl(searchControl);
+			window.removeEventListener('resize', updateInputSize);
 		};
 	}, [map, handleLocationChange, searchControlId, textPlaceholder]);
 


### PR DESCRIPTION
## Description
Dynamically set the input size attribute based on screen width.
Show only the last part of the breadcrumb on mobile.
Breadcrumbs, Share and Download buttons should not be visible when Ithe nfo Panel is opened on mobile

## Related ticket
https://rm.ewdev.ca/issues/82420
https://rm.ewdev.ca/issues/78545
https://rm.ewdev.ca/issues/78543