### PR TITLE
81967 add sea level variable

### DIFF
--- a/apps/src/components/app-sidebar.tsx
+++ b/apps/src/components/app-sidebar.tsx
@@ -26,6 +26,7 @@ import { ThresholdValuesDropdown } from '@/components/sidebar-menu-items/thresho
 import { InteractiveRegionsMenuItem } from '@/components/sidebar-menu-items/interactive-regions-menu-item';
 import { FrequenciesDropdown } from '@/components/sidebar-menu-items/frequencies-dropdown';
 import { TimePeriodsControl } from '@/components/sidebar-menu-items/time-periods-control';
+import { TimePeriodsControlForSeaLevel } from '@/components/sidebar-menu-items/time-periods-control-for-sea-level';
 import { DataValuesControl } from '@/components/sidebar-menu-items/data-values-control';
 import { MapColorsDropdown } from '@/components/sidebar-menu-items/map-colors-dropdown';
 import { VersionsDropdown } from "@/components/sidebar-menu-items/versions-dropdown";
@@ -119,7 +120,11 @@ export function AppSidebar() {
 									<FrequenciesDropdown />
 									<SidebarSeparator />
 
-									<TimePeriodsControl />
+									{climateVariable?.getId() === 'sea_level' ? (
+										<TimePeriodsControlForSeaLevel />
+									) : (
+										<TimePeriodsControl />
+									)}
 								</SidebarMenu>
 							</SidebarGroupContent>
 						</TabsContent>

--- a/apps/src/components/map-layers/sea-level-climate-variable-values.tsx
+++ b/apps/src/components/map-layers/sea-level-climate-variable-values.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState, useMemo, useContext } from 'react';
+import { useI18n } from '@wordpress/react-i18n';
+import L from 'leaflet';
+import { useClimateVariable } from "@/hooks/use-climate-variable";
+import { fetchDeltaValues } from '@/services/services';
+import SectionContext from "@/context/section-provider";
+
+interface SeaLeavelClimateVariableValuesProps {
+	latlng: L.LatLng;
+	featureId: number,
+	mode: "modal" | "panel"
+}
+
+/**
+ * SeaLevelClimateVariableValues Component
+ * ---------------------------
+ * Display the climate variable median
+ * For Seal Level climate variable
+ *
+ * Can be used in the location modal and charts panel
+ */
+const SeaLevelClimateVariableValues: React.FC<SeaLeavelClimateVariableValuesProps> = ({
+	latlng,
+	featureId,
+	mode,
+}) => {
+	const { __ } = useI18n();
+	const { climateVariable } = useClimateVariable();
+	const decimals = 0;
+	const dateRange = useMemo(() => {
+		return climateVariable?.getDateRange() ?? ["2040", "2050"];
+	}, [climateVariable]);
+	const section = useContext(SectionContext);
+
+	const [ median, setMedian ] = useState<number | null>(null);
+	const [ noDataAvailable, setNoDataAvailable ] = useState<boolean>(false);
+
+	// useEffect to retrieve location values for the current climate variable
+	useEffect(() => {
+		const variableId = climateVariable?.getId() ?? '';
+		const { lat, lng } = latlng;
+		const decadeValue = parseInt(dateRange[1]); // We get end date for this variable
+
+		const fetchData = async () => {
+			if (!decadeValue && !variableId) return;
+
+			const scenario = climateVariable?.getScenario() ?? '';
+
+			// Fetching median
+
+			// Endpoint
+			const medianEndpoint = `get-slr-gridded-values/${lat}/${lng}`;
+
+			// Params
+			const medianParams = new URLSearchParams({
+				period: String(decadeValue)
+			}).toString();
+
+			const medianData = await fetchDeltaValues({
+				endpoint: medianEndpoint,
+				varName: null,
+				frequency: null,
+				params: medianParams,
+			});
+
+			if(medianData === null) {
+				// If we don't have data
+				setNoDataAvailable(true);
+			} else {
+				const [scenarioName, percentile] = scenario.split('-');
+	
+				if(scenarioName && percentile) {
+					setMedian(medianData[scenarioName]?.[percentile] || 0);
+					setNoDataAvailable(false);
+				} else {
+					// If we don't have data
+					setNoDataAvailable(true);
+				}
+			}
+		};
+
+		fetchData();
+	}, [climateVariable, decimals, dateRange, featureId, latlng, section]);
+
+	// Value formatter (for units)
+	const valueFormatter = (value: number) => {
+		const unit = climateVariable?.getUnit();
+		return `${value.toFixed(decimals)} ${unit}`;
+	};
+
+	// Generate median div
+	const generateMedianDiv = (median: number) => {
+		const formattedMedian = valueFormatter(median);
+
+		return (
+			<div className={mode === "modal" ? "w-1/2" : ""}>
+				<div className={`font-semibold text-brand-blue ${mode === 'modal' ? 'mb-1 text-2xl' : 'text-md'}`}>
+					{ formattedMedian }
+				</div>
+				<div className={mode === "modal" ? "" : "flex gap-2"}>
+					<div className='text-xs font-semibold text-neutral-grey-medium uppercase tracking-wider'>
+						{__('Median')}
+					</div>
+				</div>
+			</div>
+		);
+	};
+
+	return (
+		<div className={mode === "modal" ? "mt-4 mb-4" : "flex-grow flex gap-6 justify-end"}>
+			{noDataAvailable ? (
+				<div>
+					<p className='text-base text-neutral-grey-medium italic'>
+						{__('No data available.')}
+					</p>
+				</div>
+			) : (
+				<>
+					<div className={mode === "modal" ? "mb-3 flex" : "flex gap-6"}>
+						{ median !== null && generateMedianDiv(median) }
+					</div>
+				</>
+			)}
+		</div>
+	);
+};
+
+export default SeaLevelClimateVariableValues;

--- a/apps/src/components/raster-map-container.tsx
+++ b/apps/src/components/raster-map-container.tsx
@@ -72,18 +72,22 @@ export default function RasterMapContainer({
 
 		const frequencyCode = getFrequencyCode(frequency);
 
-		const value = [
-				version,
-				threshold,
-				frequencyCode,
-				scenario,
-				'p50',
-				frequency,
-				'30year',
-				climateVariable?.getDataValue() === 'delta' ? 'delta7100' : '',
-			]
-			.filter(Boolean)
-			.join('-');
+		const valuesArr = [
+			version,
+			threshold,
+			frequencyCode,
+			scenario,
+		];
+		if(climateVariable?.getId() !== "sea_level") {
+			valuesArr.push('p50');
+		}
+		valuesArr.push(
+			frequency,
+			'30year',
+			climateVariable?.getDataValue() === 'delta' ? 'delta7100' : ''
+		);
+
+		const value = valuesArr.filter(Boolean).join('-');
 
 		return `CDC:${value}`;
 	}, [climateVariable])

--- a/apps/src/components/sidebar-menu-items/time-periods-control-for-sea-level.tsx
+++ b/apps/src/components/sidebar-menu-items/time-periods-control-for-sea-level.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import * as Slider from '@radix-ui/react-slider';
 import { useI18n } from '@wordpress/react-i18n';
-import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import { useAppDispatch } from '@/app/hooks';
 
 // components
 import { SidebarMenuItem } from '@/components/ui/sidebar';
@@ -12,32 +12,55 @@ import { cn } from '@/lib/utils';
 import { useClimateVariable } from "@/hooks/use-climate-variable";
 import { setTimePeriodEnd } from '@/features/map/map-slice';
 
-const TimePeriodsControl: React.FC = () => {
+const TimePeriodsControlForSeaLevel: React.FC = () => {
 	const { __ } = useI18n();
 	const dispatch = useAppDispatch();
 	const { climateVariable, setDateRange } = useClimateVariable();
-	const timePeriodEnd = useAppSelector(state => state.map.timePeriodEnd);
+	const scenario = climateVariable?.getScenario();
+	const [sliderLabel, setSliderLabel] = useState<string>('');
+	const [minYearLabel, setMinYearLabel] = useState<string>('');
+
+	const enhancedScenario = 'rcp85plus65-p50';
+	const fixedYearForEnhancedScenario = 2100;
 
 	const { min, max, interval } = climateVariable?.getDateRangeConfig() ?? {
-		min: 1950,
+		min: 2006,
 		max: 2100,
-		interval: 30,
+		interval: 10,
 	};
 
 	// Get date range from climate variable state
 	const dateRange = climateVariable?.getDateRange();
-	const [startYear, endYear] = dateRange ?? ["2040", "2070"];
+	const [startYear, endYear] = dateRange ?? ["2040", "2050"];
 
 	// Use map state for the slider
-	const sliderValue = timePeriodEnd && timePeriodEnd.length > 0
-		? timePeriodEnd
-		: [Number(endYear)];
 
-	const minYear = Number(min);
+	let sliderValue = [Number(endYear)];
+	// Special scenario (2100 is the only option)
+	if(scenario === enhancedScenario) {
+		sliderValue = [fixedYearForEnhancedScenario];
+	}
+	
 	const maxYear = Number(max);
 	const intervalYears = interval;
+	const minYear = Math.floor(Number(min) / intervalYears) * intervalYears + (intervalYears * (-1));
+
+	// Set initial values for fixed special case scenario
+	useEffect(() => {
+		// Special scenario (2100 is the only option)
+		if(scenario === enhancedScenario) {
+			dispatch(setTimePeriodEnd([fixedYearForEnhancedScenario]));
+			setDateRange([
+				(fixedYearForEnhancedScenario - intervalYears).toString(),
+				fixedYearForEnhancedScenario.toString(),
+			]);
+		}
+	}, [scenario, fixedYearForEnhancedScenario, dispatch, intervalYears, setDateRange]);
 
 	const handleChange = (values: number[]) => {
+		// If we have a fixed year for this scenario, don't allow changes
+		if(scenario === enhancedScenario) return;
+
 		let newEnd = values[0];
 
 		if (newEnd < minYear + intervalYears) {
@@ -47,15 +70,43 @@ const TimePeriodsControl: React.FC = () => {
 			newEnd = maxYear;
 		}
 
+		let newEndStr = newEnd.toString();
+		// Handle special case where end year is below min
+		if (newEnd < Number(min)) {
+			newEndStr = min.toString();
+		}
+
 		// Update both map state and climate variable state
 		dispatch(setTimePeriodEnd([newEnd]));
 
 		// Update climate variable state with the new date range
 		setDateRange([
 			(newEnd - intervalYears).toString(),
-			newEnd.toString(),
+			newEndStr,
 		]);
 	};
+
+	// Set min year label
+	useEffect(() => {
+		if (minYear) {
+			setMinYearLabel(min.toString());
+		}
+	}, [climateVariable, min, minYear]);
+
+	// Set slider label
+	useEffect(() => {
+		if (startYear && endYear) {
+			if (scenario === enhancedScenario) {
+				setSliderLabel(fixedYearForEnhancedScenario.toString());
+			} else {
+				if (endYear < min) {
+					setSliderLabel(min.toString());
+				} else {
+					setSliderLabel(endYear);
+				}
+			}
+		}
+	}, [climateVariable, startYear, endYear, min, scenario]);
 
 	return (
 		<SidebarMenuItem>
@@ -67,13 +118,15 @@ const TimePeriodsControl: React.FC = () => {
 				<Slider.Root
 					className={cn(
 						'relative flex items-center select-none',
-						'mt-14 [touch-action:none]'
+						'mt-14 [touch-action:none]',
+						scenario === enhancedScenario && 'opacity-50 cursor-not-allowed'
 					)}
 					value={sliderValue}
 					onValueChange={handleChange}
 					min={minYear + intervalYears}
 					max={maxYear}
 					step={10}
+					disabled={scenario === enhancedScenario}
 				>
 					<Slider.Track
 						className={cn(
@@ -105,8 +158,7 @@ const TimePeriodsControl: React.FC = () => {
 								'flex items-center pointer-events-none'
 							)}
 						>
-							{/* For display purposes we add 1, e.g. 2041 - 2070. */}
-							{Number(startYear) + 1} - {endYear}
+							{sliderLabel}
 							<div
 								className={cn(
 									'slider-range-tooltip',
@@ -119,14 +171,13 @@ const TimePeriodsControl: React.FC = () => {
 					</Slider.Thumb>
 				</Slider.Root>
 				<div className="flex justify-between mt-2.5 text-sm">
-					{/* For display purposes we add 1, e.g. 1951 - 2100. */}
-					<span>{minYear + 1}</span>
+					<span>{minYearLabel}</span>
 					<span>{maxYear}</span>
 				</div>
 			</div>
 		</SidebarMenuItem>
 	);
 };
-TimePeriodsControl.displayName = 'TimePeriodsControl';
+TimePeriodsControlForSeaLevel.displayName = 'TimePeriodsControlForSeaLevel';
 
-export { TimePeriodsControl };
+export { TimePeriodsControlForSeaLevel };

--- a/apps/src/config/app.config.ts
+++ b/apps/src/config/app.config.ts
@@ -42,6 +42,46 @@ const appConfig = {
 			value: "ssp585",
 			label: "SSP 5–8.5",
 		},
+		{
+			value: "rcp85plus65-p50",
+			label: "RCP8.5 enhanced scenario",
+		},
+		{
+			value: "rcp85-p05",
+			label: "RCP8.5 lower (5th percentile)",
+		},
+		{
+			value: "rcp85-p50",
+			label: "RCP8.5 median (50th percentile)",
+		},
+		{
+			value: "rcp85-p95",
+			label: "RCP8.5 upper (95th percentile)",
+		},
+		{
+			value: "rcp45-p05",
+			label: "RCP4.5 lower (5th percentile)",
+		},
+		{
+			value: "rcp45-p50",
+			label: "RCP4.5 median (50th percentile)",
+		},
+		{
+			value: "rcp45-p95",
+			label: "RCP4.5 upper (95th percentile)",
+		},
+		{
+			value: "rcp26-p05",
+			label: "RCP2.6 lower (5th percentile)",
+		},
+		{
+			value: "rcp26-p50",
+			label: "RCP2.6 median (50th percentile)",
+		},
+		{
+			value: "rcp26-p95",
+			label: "RCP2.6 upper (95th percentile)",
+		},
 	],
 	frequencies: [
 		{

--- a/apps/src/config/climate-variables.config.ts
+++ b/apps/src/config/climate-variables.config.ts
@@ -1475,6 +1475,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 		class: "SeaLevelClimateVariable",
 		threshold: "slr",
 		hasDelta: false,
+		enableColourOptions: false,
 		dateRange: [
 			"2040",
 			"2050",

--- a/apps/src/config/climate-variables.config.ts
+++ b/apps/src/config/climate-variables.config.ts
@@ -1469,6 +1469,23 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 			},
 		},
 	},
+	/** Relative Sea-Level Change */
+	{
+		id: "sea_level",
+		class: "SeaLevelClimateVariable",
+		threshold: "slr",
+		hasDelta: false,
+		dateRange: [
+			"2040",
+			"2050",
+		],
+		dateRangeConfig: {
+			min: "2006",
+			max: "2100",
+			interval: 10
+		},
+		unit: "cm",
+	},
 
 	/** Test variable */
 	{

--- a/apps/src/context/climate-variable-provider.tsx
+++ b/apps/src/context/climate-variable-provider.tsx
@@ -20,6 +20,7 @@ import {
 import RasterPrecalculatedClimateVariable from '@/lib/raster-precalculated-climate-variable';
 import RasterPrecalculatedWithDailyFormatsClimateVariable from '@/lib/raster-precalculated-with-daily-formats-climate-variable';
 import RasterAnalyzeClimateVariable from '@/lib/raster-analyze-climate-variable';
+import SeaLevelClimateVariable from '@/lib/sea-level-climate-variable';
 
 export type ClimateVariableContextType = {
 	climateVariable: ClimateVariableInterface | null;
@@ -61,6 +62,7 @@ const CLIMATE_VARIABLE_CLASS_MAP: ClassMapType = {
 	RasterPrecalculatedWithDailyFormatsClimateVariable:
 		RasterPrecalculatedWithDailyFormatsClimateVariable,
 	RasterAnalyzeClimateVariable: RasterAnalyzeClimateVariable,
+	SeaLevelClimateVariable: SeaLevelClimateVariable,
 };
 
 /**

--- a/apps/src/lib/sea-level-climate-variable.tsx
+++ b/apps/src/lib/sea-level-climate-variable.tsx
@@ -60,7 +60,7 @@ class SeaLevelClimateVariable extends RasterPrecalculatedClimateVariable {
 				[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
 				[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.NONE,
 				[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.NONE,
-				[FrequencyType.ALL_MONTHS]: FrequencyDisplayModeOption.DOWNLOAD,
+				[FrequencyType.ALL_MONTHS]: FrequencyDisplayModeOption.NONE,
 			};
 	}
 

--- a/apps/src/lib/sea-level-climate-variable.tsx
+++ b/apps/src/lib/sea-level-climate-variable.tsx
@@ -1,0 +1,108 @@
+import ClimateVariableBase from "@/lib/climate-variable-base";
+import RasterPrecalculatedClimateVariable from "@/lib/raster-precalculated-climate-variable";
+import {
+	AveragingType,
+	DownloadType,
+	FileFormatType,
+	FrequencyConfig,
+	FrequencyDisplayModeOption,
+	FrequencyType,
+	InteractiveRegionConfig,
+	InteractiveRegionOption,
+	ScenariosConfig
+} from "@/types/climate-variable-interface";
+import SeaLevelClimateVariableValues from "@/components/map-layers/sea-level-climate-variable-values";
+
+class SeaLevelClimateVariable extends RasterPrecalculatedClimateVariable {
+
+	getVersions(): string[] {
+		return ClimateVariableBase.prototype.getVersions.call(this).length > 0
+			? ClimateVariableBase.prototype.getVersions.call(this)
+			: [
+				"cmip5",
+			];
+	}
+
+	getScenariosConfig(): ScenariosConfig | null {
+		return ClimateVariableBase.prototype.getScenariosConfig.call(this)
+			? ClimateVariableBase.prototype.getScenariosConfig.call(this)
+			: {
+				cmip5: [
+					"rcp85plus65-p50",
+					"rcp85-p05",
+					"rcp85-p50",
+					"rcp85-p95",
+					"rcp45-p05",
+					"rcp45-p50",
+					"rcp45-p95",
+					"rcp26-p05",
+					"rcp26-p50",
+					"rcp26-p95",
+				],
+			};
+	}
+
+	getInteractiveRegionConfig(): InteractiveRegionConfig | null {
+		return ClimateVariableBase.prototype.getInteractiveRegionConfig.call(this)
+			? ClimateVariableBase.prototype.getInteractiveRegionConfig.call(this)
+			: {
+				[InteractiveRegionOption.GRIDDED_DATA]: true,
+				[InteractiveRegionOption.CENSUS]: false,
+				[InteractiveRegionOption.HEALTH]: false,
+				[InteractiveRegionOption.WATERSHED]: false
+			};
+	}
+
+	getFrequencyConfig(): FrequencyConfig | null {
+		return ClimateVariableBase.prototype.getFrequencyConfig.call(this)
+			? ClimateVariableBase.prototype.getFrequencyConfig.call(this)
+			: {
+				[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
+				[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.NONE,
+				[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.NONE,
+				[FrequencyType.ALL_MONTHS]: FrequencyDisplayModeOption.DOWNLOAD,
+			};
+	}
+
+	getGridType(): string | null {
+		return ClimateVariableBase.prototype.getGridType.call(this)
+			? ClimateVariableBase.prototype.getGridType.call(this)
+			: "slrgrid";
+	}
+
+	hasDelta(): boolean | undefined {
+		return ClimateVariableBase.prototype.hasDelta.call(this) !== undefined
+			? ClimateVariableBase.prototype.hasDelta.call(this)
+			: false;
+	}
+
+	getAveragingOptions(): AveragingType[] {
+		return ClimateVariableBase.prototype.getAveragingOptions.call(this).length > 0
+			? ClimateVariableBase.prototype.getAveragingOptions.call(this)
+			: [
+				AveragingType.ALL_YEARS
+			];
+	}
+
+	getFileFormatTypes(): FileFormatType[] {
+		return ClimateVariableBase.prototype.getFileFormatTypes.call(this).length > 0
+			? ClimateVariableBase.prototype.getFileFormatTypes.call(this)
+			: [
+				FileFormatType.CSV,
+				FileFormatType.JSON,
+				FileFormatType.NetCDF,
+			];
+	}
+
+	getDownloadType(): DownloadType | null {
+		return ClimateVariableBase.prototype.getDownloadType.call(this) ?? DownloadType.PRECALCULATED;
+	}
+
+	getLocationModalContent(latlng: L.LatLng, featureId: number, mode: "modal" | "panel" = "modal"): React.ReactNode {
+		return (
+			<SeaLevelClimateVariableValues latlng={latlng} featureId={featureId} mode={mode} />
+		);
+	}
+}
+
+export default SeaLevelClimateVariable;

--- a/apps/src/services/services.ts
+++ b/apps/src/services/services.ts
@@ -395,8 +395,12 @@ export const generateChartData = async (options: ChartDataOptions) => {
 export const fetchDeltaValues = async (options: DeltaValuesOptions) => {
 	try {
 		const { endpoint, varName, frequency, params } = options;
+		let url = `//dataclimatedata.crim.ca/${endpoint}`;
+		if(varName !== null) url += `/${varName}`;
+		if(frequency !== null) url += `/${frequency}`;
+		url += `?${params}`;
 
-		const response = await fetch(`//dataclimatedata.crim.ca/${endpoint}/${varName}/${frequency}?${params}`);
+		const response = await fetch(url);
 
 		if (!response.ok) {
 			throw new Error(response.statusText);

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -509,8 +509,8 @@ export interface ChartDataOptions {
 
 export interface DeltaValuesOptions {
 	endpoint: string;
-	varName: string;
-	frequency: string;
+	varName: string | null;
+	frequency: string | null;
 	params: string;
 }
 


### PR DESCRIPTION
## Description

Add sea level climate variable.

- add variable in config
- add specifics scenario to appConfig
- create a new class for this variable: SeaLevelClimateVariable
- create a new class for the value inside tooltip: SeaLevelClimateVariableValues
- had to adapt TimePeriodsControl to handle Sea level variable behavior about date range (this variable has a different interval, we have to display only the end year, it starts à 2006 but next should be 2010, then 2020, until 2100, and there's a special case inside this special case, date range has to be forced on 2100 on a specific scenario).
