### PR TITLE
Refs #78544, #82797 and #82422: Fixed info panel side. Grid Info panel and Grid info panel details.

### DIFF
--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -46,6 +46,7 @@ const MapHeader: React.FC<MapInfoProps> = ({ data }): React.ReactElement => {
 				direction: 'right',
 				position: {
 					top: ref.current?.getBoundingClientRect().bottom || 0,
+					left: 0,
 				},
 			});
 		}

--- a/apps/src/components/map-layers/location-modal.tsx
+++ b/apps/src/components/map-layers/location-modal.tsx
@@ -23,7 +23,9 @@ const LocationModal = React.forwardRef<HTMLDivElement, LocationModalProps>(
 			<div
 				ref={ref}
 				className={cn(
-					'fixed z-30 right-12 top-1/2 -translate-y-1/2 p-6 bg-white rounded-lg shadow-lg max-w-md w-full flex flex-col gap-6',
+					'fixed z-30 top-1/2 -translate-y-1/2 max-w-md w-full flex flex-col gap-6 p-6 bg-white rounded-lg shadow-lg',
+					'md:right-12 md:left-auto md:translate-x-0',
+					'left-1/2 -translate-x-1/2', // Center horizontally by default (sm and below)
 					className
 				)}
 				role="dialog"
@@ -49,4 +51,4 @@ const LocationModal = React.forwardRef<HTMLDivElement, LocationModalProps>(
 
 LocationModal.displayName = 'LocationModal';
 
-export default LocationModal; 
+export default LocationModal;

--- a/apps/src/components/map-legend-control.tsx
+++ b/apps/src/components/map-legend-control.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useI18n } from '@wordpress/react-i18n';
 
@@ -21,9 +21,26 @@ const MapLegendControl: React.FC<{
 }> = ({ data, isOpen, toggleOpen }) => {
 	const { __ } = useI18n();
 
+	// Responsive legend height
+	const [legendHeight, setLegendHeight] = useState<number>(LEGEND_HEIGHT);
+
+	useEffect(() => {
+		function handleResize() {
+			if (window.innerWidth < 768) {
+				// 60% of viewport height for mobile
+				setLegendHeight(Math.max(180, Math.floor(window.innerHeight * 0.6)));
+			} else {
+				setLegendHeight(LEGEND_HEIGHT);
+			}
+		}
+		handleResize();
+		window.addEventListener('resize', handleResize);
+		return () => window.removeEventListener('resize', handleResize);
+	}, []);
+
 	// TODO: all these calculations were made so that we could match the design as closely as possible
 	//  because the space between the labels is larger than in the original implementation.. confirm this is correct
-	const GRADIENT_HEIGHT = LEGEND_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
+	const GRADIENT_HEIGHT = legendHeight - PADDING_TOP - PADDING_BOTTOM;
 	const ITEM_HEIGHT = GRADIENT_HEIGHT / (data.length - 1);
 
 	const reducedLabels = useMemo(() => {
@@ -53,7 +70,7 @@ const MapLegendControl: React.FC<{
 						°C
 					</div>
 
-					<svg width={LEGEND_WIDTH} height={LEGEND_HEIGHT}>
+					<svg width={LEGEND_WIDTH} height={legendHeight}>
 						<defs>
 							<linearGradient
 								id="temperatureGradient"
@@ -72,7 +89,7 @@ const MapLegendControl: React.FC<{
 
 						<rect
 							width={GRADIENT_WIDTH}
-							height={LEGEND_HEIGHT}
+							height={legendHeight}
 							fill="url(#temperatureGradient)"
 							x="35"
 						/>

--- a/apps/src/components/map-legend-control.tsx
+++ b/apps/src/components/map-legend-control.tsx
@@ -24,37 +24,16 @@ const MapLegendControl: React.FC<{
 	colourType?: string;
 }> = ({ data, isOpen, toggleOpen, isCategorical, hasCustomScheme, unit, colourType }) => {
 	const [svgWidth, setSvgWidth] = useState(0);
+	const [legendHeight, setLegendHeight] = useState<number | undefined>(undefined);
 	const { __ } = useI18n();
 	const svgRef = useRef<SVGSVGElement>(null);
 
 	const isBlocksGradient = isCategorical || colourType === ColourType.DISCRETE;
-	// Responsive legend height
-	const [legendHeight, setLegendHeight] = useState<number>(LEGEND_HEIGHT);
-
-	useEffect(() => {
-		function handleResize() {
-			if (window.innerWidth < 768) {
-				// 60% of viewport height for mobile
-				setLegendHeight(Math.max(180, Math.floor(window.innerHeight * 0.6)));
-			} else {
-				setLegendHeight(LEGEND_HEIGHT);
-			}
-		}
-		handleResize();
-		window.addEventListener('resize', handleResize);
-		return () => window.removeEventListener('resize', handleResize);
-	}, []);
-
-	// TODO: all these calculations were made so that we could match the design as closely as possible
-	//  because the space between the labels is larger than in the original implementation.. confirm this is correct
-	const GRADIENT_HEIGHT = legendHeight - PADDING_TOP - PADDING_BOTTOM;
-	const ITEM_HEIGHT = GRADIENT_HEIGHT / (data.length - 1);
 
 	// Calculate dynamic height based on number of labels and minimum spacing
 	const totalLabels = isBlocksGradient ? data.length : data.length;
-	const minTotalHeight = (totalLabels - 1) * MIN_LABEL_SPACING + PADDING_TOP + PADDING_BOTTOM;
-	const GRADIENT_HEIGHT = minTotalHeight;
-	const LEGEND_HEIGHT = minTotalHeight + (isBlocksGradient ? PADDING_BOTTOM : 0);
+	const GRADIENT_HEIGHT = legendHeight !== undefined ? legendHeight : (totalLabels - 1) * MIN_LABEL_SPACING + PADDING_TOP + PADDING_BOTTOM;
+	const LEGEND_HEIGHT = GRADIENT_HEIGHT + (isBlocksGradient ? PADDING_BOTTOM : 0);
 
 	// For categorical/discrete data, we want equal height blocks for each category
 	const ITEM_HEIGHT = GRADIENT_HEIGHT / (isBlocksGradient ? data.length : (data.length - 1));
@@ -69,6 +48,19 @@ const MapLegendControl: React.FC<{
 		if (svgRef.current) {
 			setSvgWidth(svgRef.current.getBoundingClientRect().width);
 		}
+	}, []);
+
+	useEffect(() => {
+		function updateLegendHeight() {
+			if (svgRef.current) {
+				const svgTop = svgRef.current.getBoundingClientRect().y;
+				const available = window.innerHeight - svgTop - PADDING_TOP - 15; // 15px leaflet banner.
+				setLegendHeight(available);
+			}
+		}
+		updateLegendHeight();
+		window.addEventListener('resize', updateLegendHeight);
+		return () => window.removeEventListener('resize', updateLegendHeight);
 	}, []);
 
 	return (

--- a/apps/src/components/map-legend-control.tsx
+++ b/apps/src/components/map-legend-control.tsx
@@ -54,7 +54,7 @@ const MapLegendControl: React.FC<{
 		function updateLegendHeight() {
 			if (svgRef.current) {
 				const svgTop = svgRef.current.getBoundingClientRect().y;
-				const available = window.innerHeight - svgTop - PADDING_TOP - 15; // 15px leaflet banner.
+				const available = window.innerHeight - svgTop - PADDING_TOP - 20; // 15px leaflet banner.
 				setLegendHeight(available);
 			}
 		}


### PR DESCRIPTION
## Description
Fixed Text on the left side on mobile. It will not be cropped.
The Grid Info Panel is now full size on mobile and up to the right-hand side bar on desktop. Breakpoint is at md (768px)
The legend dropdown height is now dynamic.

## Related ticket
https://rm.ewdev.ca/issues/78544
https://rm.ewdev.ca/issues/82797
https://rm.ewdev.ca/issues/82422