### PR TITLE
Refs #84262 and #82420: Removed trim() and fixed input size.

### DIFF
--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -203,8 +203,14 @@ export default function SearchControl({
 		// manually trigger search when the input changes.. this fixes the issue where deleting characters doesn't trigger a search
 		const searchInput = document.querySelector(`#${searchControlId} input`);
 		searchInput?.addEventListener('input', (event) => {
-			const value = (event.target as HTMLInputElement).value.trim();
-			if (value.length >= 2) {
+			let value = (event.target as HTMLInputElement).value;
+			// Remove a single leading space, if present
+			if (value.startsWith(' ')) value = value.slice(1);
+			// If two trailing spaces are present, remove one.
+			if (value.endsWith('  ') && value.length > 1) value = value.slice(0, -1);
+
+			// Count the characters without spaces
+			if (value.replace(/ /g, '').length >= 2) {
 				searchControl.searchText(value);
 			}
 		});
@@ -215,8 +221,14 @@ export default function SearchControl({
 		function updateInputSize() {
 			if (searchInput) {
 				if (window.innerWidth < 520) {
+					// On smaller screens, set the size to 27 (smaller input).
 					searchInput.setAttribute('size', '27');
+				}
+				else if (window.innerWidth > 520 && window.innerWidth < 882) {
+					// On medium-sized screens, set the size to 35 (smaller input).
+					searchInput.setAttribute('size', '35');
 				} else {
+					// On larger screens, set the size to 48 (default for larger screens).
 					searchInput.setAttribute('size', '48'); // Or set to your default
 				}
 			}


### PR DESCRIPTION
## Description
Removed trim() on the map search control and added new trim logic.
Fixed input size on tablet size.

## Related ticket
https://rm.ewdev.ca/issues/84262
https://rm.ewdev.ca/issues/82420