### PR TITLE
Refs #85764: Styled Colours, Font Size and Bullet point space.

### DIFF
--- a/apps/src/Global.css
+++ b/apps/src/Global.css
@@ -289,3 +289,15 @@
 		transform: scale(1);
 	}
 }
+
+.download-summary-bullet {
+	list-style-position: inside;
+	padding-left: 0;
+}
+.download-summary-bullet li::before {
+	content: '';
+	margin-left: -10px;
+}
+.download-summary-bullet li::marker {
+	color: #d1d5db; /* Tailwind gray-300 */
+}

--- a/apps/src/components/download/step-summary.tsx
+++ b/apps/src/components/download/step-summary.tsx
@@ -22,14 +22,14 @@ const VariableOptionsSummary: React.FC = () => {
 	const analysisFieldValues = climateVariable.getAnalysisFieldValues?.() ?? {};
 
 	return (
-			<ul className="list-disc list-inside text-dark-purple">
-				{climateVariable.getVersions().length > 0 && (<li key={version}><strong>Version:</strong> {version || 'N/A'}</li>)}
+			<ul className="download-summary-bullet list-disc list-inside">
+				{climateVariable.getVersions().length > 0 && (<li key={version}><span className='text-dark-purple text-sm'>Version:</span> <span className="uppercase">{version || 'N/A'}</span></li>)}
 				{analysisFields.map(({ key, label, unit }) => {
 					const value = analysisFieldValues[key] ?? '-';
 
 					return (
-						<li key={key}>
-							<span className='font-bold'>{label}</span>: {value} {unit}
+						<li className="summary-item" key={key}>
+							<span className='text-gray-600 text-sm'>{label}</span>: <span className="uppercase">{value} {unit}</span>
 						</li>
 					);
 				})}


### PR DESCRIPTION
## Description
Fixes for Variable Option in the Summary block in the Download section:
- Reduce the space between the bullet point and the label (like Version and Minimum Consecutive) and give the bullet point a light gray color.
- Reduce the size of the labels (like Version and Minimum Consecutive) a little and make the style not bold and make their color a bit gray lighter.
- Make the color of values, like CMIP6 or -2 C ..etc as blue, the same we can see on "3 selected" for example.
https://evolvingweb.slack.com/archives/C07ME79QCT1/p1745506488612129?thread_ts=1745505842.149689&cid=C07ME79QCT1
- Display version value in all capital letters: e.g., CMIP6 instead of cmip6
## Related ticket
https://rm.ewdev.ca/issues/85764


The tickets have three other points to be covered, which are dependent on the Variables Option Labels, Description and Help.
