### PR TITLE
Refs #84908: Removed absolute position and right padding from sidebar filters group.

### DIFF
--- a/apps/src/components/app-sidebar.tsx
+++ b/apps/src/components/app-sidebar.tsx
@@ -90,7 +90,7 @@ export function AppSidebar() {
 	return (
 		<Sidebar>
 			<SidebarContent className={'overflow-x-hidden'}>
-				<SidebarGroup className={'absolute pr-4'}>
+				<SidebarGroup>
 					<Tabs defaultValue="explore" className="mb-6">
 						<TabsList>
 							<TabsTrigger value="explore">


### PR DESCRIPTION
## Description
Removed absolute position and right padding from sidebar filters group.

## Related ticket
https://rm.ewdev.ca/issues/84908?issue_count=6&issue_position=1&next_issue_id=82018
