### PR TITLE
81967 station variables config

### DIFF
--- a/apps/src/components/app-sidebar.tsx
+++ b/apps/src/components/app-sidebar.tsx
@@ -41,6 +41,7 @@ import LayerOpacities from '@/components/ui/layer-opacities';
 import { PostData } from '@/types/types';
 import { setDataset } from '@/features/map/map-slice';
 import { useAppDispatch, useAppSelector } from "@/app/hooks";
+import { ScenariosConfig, FrequencyConfig, FrequencyType, FrequencyDisplayModeOption } from "@/types/climate-variable-interface";
 
 /**
  * A `Sidebar` component that provides a tabbed interface for exploring data or adjusting map settings.
@@ -80,11 +81,27 @@ export function AppSidebar() {
 		selectClimateVariable(variable, dataset);
 	}
 
+	// Show version dropdown if the climate variable has versions
+	const showVersionDropdown = (climateVariable?.getVersions()?.length ?? 0) > 0;
 	// We don't need to show if there's only 1 option.
 	const showThreshold = climateVariable && climateVariable.getThresholds() && climateVariable.getThresholds().length > 1;
-
+	// Show emission scenarios control if the climate variable has scenarios
+	const scenariosConfig = climateVariable?.getScenariosConfig() ?? {} as ScenariosConfig;
+	const showEmissionScenariosControl = Object.keys(scenariosConfig).length > 0;
+	// Show interactive regions menu item if the climate variable is in region interactive mode
+	const showInteractiveRegionsMenuItem = climateVariable?.getInteractiveMode() === 'region';
+	// show the frequencies dropdown if the climate variable has frequency config
+	const frequencyConfig = climateVariable?.getFrequencyConfig() ?? {} as FrequencyConfig;
+	const showFrequenciesDropdown = Object.keys(frequencyConfig).length > 0
+		&& (frequencyConfig[FrequencyType.ANNUAL] !== FrequencyDisplayModeOption.NONE
+			|| frequencyConfig[FrequencyType.MONTHLY] !== FrequencyDisplayModeOption.NONE
+			|| frequencyConfig[FrequencyType.SEASONAL] !== FrequencyDisplayModeOption.NONE
+			|| frequencyConfig[FrequencyType.ALL_MONTHS] !== FrequencyDisplayModeOption.NONE);
+	// Show the time periods control if the climate variable has date range config
+	const showTimePeriodsControl = climateVariable?.getDateRangeConfig() !== null;
+	// Show the data values control if the climate variable has delta
 	const hasDelta = climateVariable && climateVariable.hasDelta();
-
+	// Show the map colors dropdown if the climate variable has color options
 	const hasColourOptions = climateVariable && climateVariable.getColourOptionsStatus();
 
 	return (
@@ -107,23 +124,37 @@ export function AppSidebar() {
 									<VariablesMenuItem />
 									<SidebarSeparator />
 
-									<VersionsDropdown />
+									{showVersionDropdown && <VersionsDropdown />}
 									{showThreshold && <ThresholdValuesDropdown />}
-									<SidebarSeparator />
+									{(showVersionDropdown || showThreshold) && <SidebarSeparator />}
 
-									<EmissionScenariosControl />
-									<SidebarSeparator />
+									{showEmissionScenariosControl && (
+										<>
+											<EmissionScenariosControl />
+											<SidebarSeparator />
+										</>
+									)}
 
-									<InteractiveRegionsMenuItem />
-									<SidebarSeparator />
+									{showInteractiveRegionsMenuItem && (
+										<>
+											<InteractiveRegionsMenuItem />
+											<SidebarSeparator />
+										</>
+									)}
 
-									<FrequenciesDropdown />
-									<SidebarSeparator />
+									{showFrequenciesDropdown && (
+										<>
+											<FrequenciesDropdown />
+											<SidebarSeparator />
+										</>
+									)}
 
-									{climateVariable?.getId() === 'sea_level' ? (
-										<TimePeriodsControlForSeaLevel />
-									) : (
-										<TimePeriodsControl />
+									{showTimePeriodsControl && (
+										climateVariable?.getId() === 'sea_level' ? (
+											<TimePeriodsControlForSeaLevel />
+										) : (
+											<TimePeriodsControl />
+										)
 									)}
 								</SidebarMenu>
 							</SidebarGroupContent>

--- a/apps/src/components/download/step-send-request.tsx
+++ b/apps/src/components/download/step-send-request.tsx
@@ -64,6 +64,7 @@ const StepSendRequest = React.forwardRef<StepComponentRef>((_, ref) => {
 		{ value: FileFormatType.CSV, label: 'CSV' },
 		{ value: FileFormatType.JSON, label: 'JSON' },
 		{ value: FileFormatType.NetCDF, label: 'NetCDF' },
+		{ value: FileFormatType.GeoJSON, label: 'GeoJSON' },
 	].filter((option) =>
 		climateVariable?.getFileFormatTypes()?.includes(option.value)
 	);

--- a/apps/src/components/map-layers/interactive-stations-layer.tsx
+++ b/apps/src/components/map-layers/interactive-stations-layer.tsx
@@ -1,0 +1,43 @@
+/**
+ * Component that adds interaction to the map depending on the selected region (gridded data, watershed, health, census).
+ */
+import React, { useEffect, useState } from 'react';
+import 'leaflet.vectorgrid';
+
+import { fetchStationsList } from '@/services/services';
+
+interface InteractiveStationsLayerProps {
+	onLocationModalOpen: (content: React.ReactNode) => void;
+	onLocationModalClose: () => void;
+}
+
+interface Station {
+	id: string;
+	name: string;
+	coordinates: {
+		latitude: number;
+		longitude: number;
+	}
+}
+
+const InteractiveStationsLayer: React.FC<InteractiveStationsLayerProps> = () => {
+	const [stations, setStations] = useState<Station[]>([]);
+
+	useEffect(() => {
+		const fetchStations = async () => {
+			try {
+				const stationsList = await fetchStationsList();
+				setStations(stationsList);
+				console.log(stations);
+			} catch (error) {
+				console.error('Error fetching stations list:', error);
+			}
+		};
+
+		fetchStations();
+	}, []);
+
+	return null;
+};
+
+export default InteractiveStationsLayer;

--- a/apps/src/components/raster-map-container.tsx
+++ b/apps/src/components/raster-map-container.tsx
@@ -8,6 +8,7 @@ import ZoomControl from '@/components/map-layers/zoom-control';
 import MapEvents from '@/components/map-layers/map-events';
 import SearchControl from '@/components/map-layers/search-control';
 import InteractiveRegionsLayer from '@/components/map-layers/interactive-regions-layer';
+import InteractiveStationsLayer from '@/components/map-layers/interactive-stations-layer';
 import LocationModal from '@/components/map-layers/location-modal';
 
 import { useAppSelector } from '@/app/hooks';
@@ -117,7 +118,9 @@ export default function RasterMapContainer({
 				onUnmount={onUnmount}
 				onLocationModalClose={handleLocationModalClose}
 			/>
-			<MapLegend url={`${GEOSERVER_BASE_URL}/geoserver/wms?service=WMS&version=1.1.0&request=GetLegendGraphic&format=application/json&layer=${layerValue}`} />
+			{climateVariable?.getInteractiveMode() === 'region' && (
+				<MapLegend url={`${GEOSERVER_BASE_URL}/geoserver/wms?service=WMS&version=1.1.0&request=GetLegendGraphic&format=application/json&layer=${layerValue}`} />
+			)}
 			<CustomPanesLayer />
 			<VariableLayer layerValue={layerValue} />
 			<ZoomControl />
@@ -130,11 +133,19 @@ export default function RasterMapContainer({
 				{locationModalContent}
 			</LocationModal>
 
-			<InteractiveRegionsLayer
-				scenario={scenario}
-				onLocationModalOpen={handleLocationModalOpen}
-				onLocationModalClose={handleLocationModalClose}
-			/>
+			{climateVariable?.getInteractiveMode() === 'region' && (
+				<InteractiveRegionsLayer
+					scenario={scenario}
+					onLocationModalOpen={handleLocationModalOpen}
+					onLocationModalClose={handleLocationModalClose}
+				/>
+			)}
+			{climateVariable?.getInteractiveMode() === 'station' && (
+				<InteractiveStationsLayer
+					onLocationModalOpen={handleLocationModalOpen}
+					onLocationModalClose={handleLocationModalClose}
+				/>
+			)}
 
 			<TileLayer
 				attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'

--- a/apps/src/config/app.config.ts
+++ b/apps/src/config/app.config.ts
@@ -39,6 +39,10 @@ const appConfig = {
 			label: "SSP 2–4.5",
 		},
 		{
+			value: "ssp370",
+			label: "SSP 3-7.0",
+		},
+		{
 			value: "ssp585",
 			label: "SSP 5–8.5",
 		},

--- a/apps/src/config/climate-variables.config.ts
+++ b/apps/src/config/climate-variables.config.ts
@@ -1604,4 +1604,42 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 			FileFormatType.GeoJSON,
 		],
 	},
+	/** Daily AHCCD Temperature and Precipitation */
+	{
+		id: "daily_ahccd_temperature_and_precipitation",
+		class: "StationClimateVariable",
+		threshold: "ahccd",
+		hasDelta: false,
+	},
+	/** Future Building Design Value Summaries */
+	{
+		id: "future_building_design_value_summaries",
+		class: "StationClimateVariable",
+		threshold: "bdv",
+		hasDelta: false,
+	},
+	/** Short-duration Rainfall IDF Data */
+	{
+		id: "short_duration_rainfall_idf_data",
+		class: "StationClimateVariable",
+		threshold: "idf",
+		hasDelta: false,
+	},
+	/** Station Data */
+	{
+		id: "station_data",
+		class: "StationClimateVariable",
+		threshold: "station-data",
+		versions: [
+			"cmip6",
+		],
+		scenarios: {
+			cmip6: [
+				"ssp126",
+				"ssp245",
+				"ssp585",
+				"ssp370",
+			],
+		},
+	},
 ];

--- a/apps/src/config/climate-variables.config.ts
+++ b/apps/src/config/climate-variables.config.ts
@@ -1592,4 +1592,16 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 		},
 		unit: "cm",
 	},
+	/** MSC Climate Normals 1981-2010 */
+	{
+		id: "msc_climate_normals",
+		class: "StationClimateVariable",
+		threshold: "climate-normals",
+		hasDelta: false,
+		enableColourOptions: false,
+		fileFormatTypes: [
+			FileFormatType.CSV,
+			FileFormatType.GeoJSON,
+		],
+	},
 ];

--- a/apps/src/context/climate-variable-provider.tsx
+++ b/apps/src/context/climate-variable-provider.tsx
@@ -22,6 +22,7 @@ import RasterPrecalculatedClimateVariable from '@/lib/raster-precalculated-clima
 import RasterPrecalculatedWithDailyFormatsClimateVariable from '@/lib/raster-precalculated-with-daily-formats-climate-variable';
 import RasterAnalyzeClimateVariable from '@/lib/raster-analyze-climate-variable';
 import SeaLevelClimateVariable from '@/lib/sea-level-climate-variable';
+import StationClimateVariable from '@/lib/station-climate-variable';
 
 export type ClimateVariableContextType = {
 	climateVariable: ClimateVariableInterface | null;
@@ -68,6 +69,7 @@ const CLIMATE_VARIABLE_CLASS_MAP: ClassMapType = {
 		RasterPrecalculatedWithDailyFormatsClimateVariable,
 	RasterAnalyzeClimateVariable: RasterAnalyzeClimateVariable,
 	SeaLevelClimateVariable: SeaLevelClimateVariable,
+	StationClimateVariable: StationClimateVariable,
 };
 
 /**

--- a/apps/src/lib/climate-variable-base.tsx
+++ b/apps/src/lib/climate-variable-base.tsx
@@ -13,6 +13,7 @@ import {
 	FrequencyConfig,
 	GridCoordinates,
 	GridRegion,
+	InteractiveMode,
 	InteractiveRegionConfig,
 	InteractiveRegionOption,
 	ScenariosConfig,
@@ -123,6 +124,10 @@ class ClimateVariableBase implements ClimateVariableInterface {
 
 	getUnit(): string {
 		return this._config.unit ?? '';
+	}
+
+	getInteractiveMode(): InteractiveMode {
+		return this._config.interactiveMode ?? 'region';
 	}
 
 	getInteractiveRegionConfig(): InteractiveRegionConfig | null {

--- a/apps/src/lib/station-climate-variable.tsx
+++ b/apps/src/lib/station-climate-variable.tsx
@@ -1,0 +1,81 @@
+import ClimateVariableBase from "@/lib/climate-variable-base";
+import RasterPrecalculatedClimateVariable from "@/lib/raster-precalculated-climate-variable";
+import {
+	AveragingType,
+	DownloadType,
+	FileFormatType,
+	FrequencyConfig,
+	FrequencyDisplayModeOption,
+	FrequencyType,
+	InteractiveMode,
+	ScenariosConfig,
+	DateRangeConfig,
+} from "@/types/climate-variable-interface";
+
+class StationClimateVariable extends RasterPrecalculatedClimateVariable {
+
+	getVersions(): string[] {
+		return ClimateVariableBase.prototype.getVersions.call(this)
+			? ClimateVariableBase.prototype.getVersions.call(this)
+			: [];
+	}
+
+	getScenariosConfig(): ScenariosConfig | null {
+		return ClimateVariableBase.prototype.getScenariosConfig.call(this)
+			? ClimateVariableBase.prototype.getScenariosConfig.call(this)
+			: {};
+	}
+
+	getInteractiveMode(): InteractiveMode {
+		return 'station';
+	}
+
+	getFrequencyConfig(): FrequencyConfig | null {
+		return ClimateVariableBase.prototype.getFrequencyConfig.call(this)
+			? ClimateVariableBase.prototype.getFrequencyConfig.call(this)
+			: {
+				[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.NONE,
+				[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.NONE,
+				[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.NONE,
+				[FrequencyType.ALL_MONTHS]: FrequencyDisplayModeOption.NONE,
+			};
+	}
+
+	getDateRangeConfig(): DateRangeConfig | null {
+		return ClimateVariableBase.prototype.getDateRangeConfig.call(this)
+			? ClimateVariableBase.prototype.getDateRangeConfig.call(this)
+			: null;
+	}
+
+	hasDelta(): boolean | undefined {
+		return ClimateVariableBase.prototype.hasDelta.call(this) !== undefined
+			? ClimateVariableBase.prototype.hasDelta.call(this)
+			: false;
+	}
+
+	getAveragingOptions(): AveragingType[] {
+		return ClimateVariableBase.prototype.getAveragingOptions.call(this).length > 0
+			? ClimateVariableBase.prototype.getAveragingOptions.call(this)
+			: [];
+	}
+
+	getFileFormatTypes(): FileFormatType[] {
+		return ClimateVariableBase.prototype.getFileFormatTypes.call(this).length > 0
+			? ClimateVariableBase.prototype.getFileFormatTypes.call(this)
+			: [
+				FileFormatType.CSV,
+				FileFormatType.NetCDF,
+			];
+	}
+
+	getDownloadType(): DownloadType | null {
+		return ClimateVariableBase.prototype.getDownloadType.call(this) ?? DownloadType.PRECALCULATED;
+	}
+
+	getLocationModalContent(): React.ReactNode {
+		// We don't display any value in the modal for station climate variables
+		return null;
+	}
+}
+
+export default StationClimateVariable;

--- a/apps/src/services/services.ts
+++ b/apps/src/services/services.ts
@@ -445,3 +445,42 @@ export const fetchChoroValues = async (options: ChoroValuesOptions) => {
 		})
 		.then((json) => json);
 };
+
+
+/**
+ * Fetches the list of climate stations from weather.gc.ca API.
+ *
+ * @returns A list of stations with their names, ids and coords.
+ */
+export const fetchStationsList = async () => {
+	try {
+		const url = 'https://api.weather.gc.ca/collections/climate-stations/items?f=json&limit=10000&properties=STATION_NAME,STN_ID&startindex=0&HAS_NORMALS_DATA=Y';
+
+		const response = await fetch(url, {
+			method: 'GET',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+		});
+
+		if (!response.ok) {
+			throw new Error(`Failed to fetch stations list: ${response.statusText}`);
+		}
+
+		const data = await response.json();
+
+		// Extract and return the stations list
+		return data.features?.map((feature: { properties: { STATION_NAME: string; STN_ID: string }; geometry: { coordinates: [number, number] } }) => ({
+			name: feature.properties.STATION_NAME,
+			id: feature.properties.STN_ID,
+			coordinates: {
+				lat: feature.geometry.coordinates[1],
+				lng: feature.geometry.coordinates[0],
+			}
+		})) || [];
+	} catch (error) {
+		console.error('Error fetching stations list:', error);
+		throw error;
+	}
+};

--- a/apps/src/types/climate-variable-interface.ts
+++ b/apps/src/types/climate-variable-interface.ts
@@ -14,6 +14,8 @@ export interface ThresholdInterface {
 	label: string;
 }
 
+export type InteractiveMode = 'region' | 'station';
+
 export enum InteractiveRegionOption {
 	GRIDDED_DATA = "gridded_data",
 	CENSUS = "census",
@@ -86,6 +88,7 @@ export enum FileFormatType {
 	CSV = "csv",
 	JSON = "json",
 	NetCDF = "netcdf",
+	GeoJSON = "geojson",
 }
 
 export enum ColourType {
@@ -204,6 +207,9 @@ export interface ClimateVariableConfigInterface {
 
 	/** Unit */
 	unit?: string;
+
+	/** InteractiveMode */
+	interactiveMode?: InteractiveMode;
 
 	/** Configuration defining interactive region options and their status */
 	interactiveRegionConfig?: InteractiveRegionConfig;
@@ -341,6 +347,8 @@ export interface ClimateVariableInterface {
 	getLayerStyles(): string;
 
 	getUnit(): string;
+
+	getInteractiveMode(): InteractiveMode;
 
 	getInteractiveRegionConfig(): InteractiveRegionConfig | null;
 


### PR DESCRIPTION
## Description

Station variables config

Add variables: MSC Climate Normals 1981-2010, Daily AHCCD Temperature and Precipitation, Future Building Design Value Summaries, Short-duration Rainfall IDF Data and Station Data.

Add StationClimateVariable class.
Create InteractiveMode attribute in climate variable interface. Can be 'region' (for every raster variables) or 'station'.
Add InteractiveStationsLayer component to render stations on the map. Currently it only fetches stations list (with name and coords for each).
Update Sidebar to hide useless options for station variables.

