### PR TITLE
refs #85760: remove browser language.

### DIFF
--- a/apps/src/context/locale-provider.tsx
+++ b/apps/src/context/locale-provider.tsx
@@ -21,14 +21,6 @@ export const LocaleProvider: React.FC<{ children: React.ReactNode }> = ({
 
 	const [locale, setLocale] = useState<Locale>(initialLocale);
 
-	useEffect(() => {
-		// Client-side locale
-		const browserLocale = navigator.language;
-		if (browserLocale.startsWith('fr')) {
-			setLocale('fr');
-		}
-	}, []);
-
 	return (
 		<LocaleContext.Provider value={{ locale, setLocale }}>
 			{children}


### PR DESCRIPTION
## Description

We changed the locale based on the navigator locale. This is not needed, as it is being set by WordPress, depending on the domain.

