### PR TITLE
refs #85904: adding a back link to WordPress.

### DIFF
--- a/apps/src/components/download/app.tsx
+++ b/apps/src/components/download/app.tsx
@@ -8,6 +8,7 @@ import { AnimatedPanelProvider } from '@/context/animated-panel-provider';
 import { DownloadProvider } from '@/context/download-provider';
 import { LocaleProvider } from '@/context/locale-provider';
 import { useLeaflet } from '@/hooks/use-leaflet';
+import Header from "@/components/header.tsx";
 
 const App: React.FC = () => {
 	useLeaflet();
@@ -17,6 +18,7 @@ const App: React.FC = () => {
 			<MapProvider>
 				<AnimatedPanelProvider>
 					<DownloadProvider>
+						<Header />
 						<div className="min-h-screen bg-cold-grey-1">
 							<div className="max-w-6xl mx-auto py-10">
 								<div className="flex flex-col sm:flex-row gap-4">

--- a/apps/src/components/header.tsx
+++ b/apps/src/components/header.tsx
@@ -13,7 +13,7 @@ export default function Header(): JSX.Element {
 					{__('Climate Data')}
 				</h2>
 			</div>
-			<a href="#" className="flex gap-x-2 px-4 py-2">
+			<a href="/" className="flex gap-x-2 px-4 py-2">
 				<span className="underline text-sm">
 					{__('Go back to the main website')}
 				</span>


### PR DESCRIPTION
## Description

Fix the back link to WordPress on the Map app.
Add the header with the back link on the Download app.
