### PR TITLE
Refs #81981 generate map image from server api

### DIFF
--- a/apps/src/components/header.tsx
+++ b/apps/src/components/header.tsx
@@ -6,7 +6,7 @@ export default function Header(): JSX.Element {
 	const { __ } = useI18n();
 
 	return (
-		<header className="flex items-center justify-between px-4 py-1.5">
+		<header id="header" className="flex items-center justify-between px-4 py-1.5">
 			<div className="flex items-center">
 				<img src={Logo} alt={__('Climate Data')} />
 				<h2 className="py-2 px-4 text-zinc-900 text-base font-light leading-tight">

--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -76,7 +76,7 @@ const MapHeader: React.FC<MapInfoProps> = ({ data }): React.ReactElement => {
 
 	return (
 		<>
-			<aside className="map-header relative z-20">
+			<aside id="header-map" className="map-header relative z-20">
 				<div
 					ref={ref}
 					className="absolute top-0 left-0 overflow-y-auto w-full"

--- a/apps/src/components/map-info/download-map-modal.tsx
+++ b/apps/src/components/map-info/download-map-modal.tsx
@@ -41,8 +41,6 @@ const DownloadMapModal: React.FC<{
 	onClose: () => void;
 	title: string;
 }> = ({ isOpen, onClose, title }) => {
-	//const { climateVariable } = useClimateVariable();
-	//const [downloadUrl, setDownloadUrl] = useState<string>('default_value');
 	const [isGenerating, setIsGenerating] = useState<boolean>(false);
 
 	// Get dataset and variable information for download URL

--- a/apps/src/components/map-info/download-map-modal.tsx
+++ b/apps/src/components/map-info/download-map-modal.tsx
@@ -31,6 +31,8 @@ declare global {
 				prepare_raster?: () => void;
 			};
 		};
+		URL_ENCODER_SALT: string;
+		DATA_URL: string;
 	}
 }
 
@@ -47,9 +49,9 @@ const DownloadMapModal: React.FC<{
 	const dataset = useAppSelector((state) => state.map.dataset);
 	const climateVariableData = useAppSelector((state) => state.climateVariable.data);
 
-	// @todo to be replaced with real value.
-	const salt: string = '';
-	const data_url: string = '';
+	// Get Salt and Data URL to download Image Map from Server API.
+	const salt: string = window.URL_ENCODER_SALT;
+	const data_url: string = window.DATA_URL;
 
 	// Used by the Download Image Map server.
 	useEffect(() => {
@@ -91,7 +93,6 @@ const DownloadMapModal: React.FC<{
 	 * Fetches the image from the provided downloadUrl as a Blob and triggers a file download in the browser.
 	 * Sets a loading state while the request is in progress.
 	 * Includes an artificial delay for demonstration/testing purposes.
-	 * @param e - The click event from the anchor element
 	 */
 	const handleDownloadClick = async () => {
 		const mapUrl = new URL(window.location.href);
@@ -101,11 +102,15 @@ const DownloadMapModal: React.FC<{
 		const encoded_url = encodeURL(mapUrl.toString(), salt).encoded;
 		// Generate the generateMap URL.
 		const api_url = data_url + '/raster?url=' + encoded_url;
-		if (!api_url) return;
+		if (!api_url) {
+			return;
+		}
 		setIsGenerating(true);
 		try {
 			const response = await fetch(api_url);
-			if (!response.ok) throw new Error('Network response was not ok');
+			if (!response.ok) {
+				throw new Error('Network response was not ok');
+			}
 			const blob = await response.blob();
 			downloadBlob(blob, `${title}-map.png`);
 		} catch (error) {

--- a/apps/src/components/map-info/download-map-modal.tsx
+++ b/apps/src/components/map-info/download-map-modal.tsx
@@ -9,7 +9,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { Download, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { encodeURL, prepareRaster } from '@/lib/utils';
-import { useClimateVariable } from "@/hooks/use-climate-variable";
 import { useAppSelector } from '@/app/hooks';
 import { WP_API_DOMAIN } from '@/lib/constants';
 
@@ -35,16 +34,15 @@ declare global {
 	}
 }
 
-// @todo: Currently does nothing. The image must be generated from the server.
 const DownloadMapModal: React.FC<{
 	isOpen: boolean;
 	onClose: () => void;
 	title: string;
 }> = ({ isOpen, onClose, title }) => {
-	const { climateVariable } = useClimateVariable();
-	const [downloadUrl, setDownloadUrl] = useState<string>('default_value');
+	//const { climateVariable } = useClimateVariable();
+	//const [downloadUrl, setDownloadUrl] = useState<string>('default_value');
 	const [isGenerating, setIsGenerating] = useState<boolean>(false);
-	
+
 	// Get dataset and variable information for download URL
 	const dataset = useAppSelector((state) => state.map.dataset);
 	const climateVariableData = useAppSelector((state) => state.climateVariable.data);
@@ -52,14 +50,6 @@ const DownloadMapModal: React.FC<{
 	// @todo to be replaced with real value.
 	const salt: string = '';
 	const data_url: string = '';
-
-	useEffect(() => {
-		// @todo Update it with the Relative url to the Download Page.
-		// It should listen to climateData variables changes.
-		// Or generated when the modal is opened.
-		setDownloadUrl('download_page_step_3_value')
-	}, [climateVariable]);
-
 
 	// Used by the Download Image Map server.
 	useEffect(() => {
@@ -117,8 +107,6 @@ const DownloadMapModal: React.FC<{
 			const response = await fetch(api_url);
 			if (!response.ok) throw new Error('Network response was not ok');
 			const blob = await response.blob();
-			// @todo to be removed. The timeout has been added to test the Generating message.
-			await new Promise(res => setTimeout(res, 2000));
 			downloadBlob(blob, `${title}-map.png`);
 		} catch (error) {
 			console.error('Failed to generate download URL:', error);
@@ -132,7 +120,7 @@ const DownloadMapModal: React.FC<{
 		if (!dataset || !climateVariableData || !climateVariableData.id) {
 			return `${WP_API_DOMAIN}/download-app/`;
 		}
-		
+
 		return `${WP_API_DOMAIN}/download-app/?dataset=${encodeURIComponent(dataset.term_id.toString())}&var=${encodeURIComponent(climateVariableData.id)}`;
 	}, [dataset, climateVariableData]);
 

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -248,6 +248,7 @@ export default function SearchControl({
 				'search-control absolute top-24 left-4 z-20 flex items-center space-x-1',
 				className
 			)}
+			id='map-search-control'
 		>
 			<div
 				id={searchControlId}

--- a/apps/src/components/map-legend-control.tsx
+++ b/apps/src/components/map-legend-control.tsx
@@ -49,6 +49,7 @@ const MapLegendControl: React.FC<{
 	return (
 		<div className="space-y-[5px] w-[91px]">
 			<button
+				id="legend-toggle"
 				className="legend-toggle flex items-center space-x-2 bg-white border border-cold-grey-3 rounded-md py-1 px-2.5"
 				onClick={toggleOpen}
 			>

--- a/apps/src/components/ui/sidebar.tsx
+++ b/apps/src/components/ui/sidebar.tsx
@@ -35,6 +35,7 @@ const Sidebar = React.forwardRef<
 			collapsible = 'offcanvas',
 			className,
 			children,
+			id='map-sidebar',
 			...props
 		},
 		ref
@@ -51,6 +52,7 @@ const Sidebar = React.forwardRef<
 						'bg-sidebar text-sidebar-foreground',
 						className
 					)}
+					id={id}
 					ref={ref}
 					{...props}
 				>
@@ -109,6 +111,7 @@ const Sidebar = React.forwardRef<
 				data-collapsible={state === 'collapsed' ? collapsible : ''}
 				data-variant={variant}
 				data-side={side}
+				id={id}
 			>
 				{/* This is what handles the sidebar gap on desktop */}
 				<div
@@ -156,6 +159,7 @@ const SidebarTrigger = React.forwardRef<
 			ref={ref}
 			data-sidebar="trigger"
 			variant="ghost"
+			id="sidebar-toggle"
 			size="icon"
 			className={cn('h-7 w-7', className)}
 			onClick={(event) => {
@@ -183,6 +187,7 @@ const SidebarRail = React.forwardRef<
 			data-sidebar="rail"
 			aria-label="Toggle Sidebar"
 			tabIndex={-1}
+			id="sidebar-toggle"
 			onClick={toggleSidebar}
 			title="Toggle Sidebar"
 			className={cn(

--- a/apps/src/components/ui/zoom-buttons.tsx
+++ b/apps/src/components/ui/zoom-buttons.tsx
@@ -28,7 +28,7 @@ const ZoomButtons: React.FC<ZoomControlProps> = ({
 	);
 
 	return (
-		<div className="absolute bottom-6 left-6 z-20 overflow-y-auto">
+		<div id="map-zoom-control" className="absolute bottom-6 left-6 z-20 overflow-y-auto">
 			<div
 				className={cn(
 					'zoom-control',

--- a/apps/src/lib/utils.ts
+++ b/apps/src/lib/utils.ts
@@ -133,3 +133,67 @@ export const getCommonPrefix = (strings: string[]) => {
 	}
 	return prefix;
 }
+
+/**
+ * Generates a hash code from a string using a basic bitwise algorithm.
+ *
+ * Note: This is a non-cryptographic hash function and should not be used for security purposes.
+ *
+ * @param {string} s - The input string to hash.
+ * @returns {number} The resulting hash code.
+ */
+export const hashCode = (s: string)=> {
+	return s.split('').reduce(function (a: number, b: string) {
+		a = (a << 5) - a + b.charCodeAt(0);
+		return a & a;
+	}, 0);
+}
+
+/**
+ * Encodes a URL with a salt using base64 and URL encoding.
+ *
+ * The URL is combined with a hash generated from the URL and salt,
+ * then base64-encoded and URL-encoded to ensure safe transmission.
+ *
+ * @param {string} url - The URL to encode.
+ * @param {string} salt - The salt used for hash generation.
+ * @returns {{ encoded: string, hash: number }} An object containing the encoded URL and its hash.
+ */
+export const encodeURL = (url: string, salt: string) => {
+	const hash = hashCode(url + salt);
+	const encoded = encodeURIComponent(btoa(`${url}|${hash}`));
+	return { encoded, hash };
+};
+
+/**
+ * Modify the DOM to prepare the "Explore Maps" page for a screenshot.
+ *
+ * This function is designed to be executed by an external script (e.g. via Selenium)
+ * before taking a screenshot. It removes certain UI elements and applies a specific
+ * class to the map container to render the map in a cleaner, full-screen layout.
+ *
+ * Note: This function does not revert changes. A full page reload is required to restore the original UI.
+ */
+export function prepareRaster(): void {
+	// Simulate a click on the legend toggle button
+	const legendToggle = document.getElementById('legend-toggle');
+	if (legendToggle instanceof HTMLElement) {
+		legendToggle.click();
+	}
+	// Remove elements that should not appear in the screenshot
+	['map-sidebar', 'header', 'sidebar-toggle', 'header-map', 'map-search-control', 'map-zoom-control'].forEach(id => {
+		const el = document.getElementById(id);
+		if (el) {
+			el.remove();
+		}
+	});
+
+	// Remove all tooltip elements
+	document.querySelectorAll('.tooltip').forEach(el => el.remove());
+
+	// Add 'to-raster' class to the map container to adjust its appearance for raster output
+	const mapObjects = document.getElementById('map-objects');
+	if (mapObjects) {
+		mapObjects.classList.add('to-raster');
+	}
+}

--- a/apps/src/lib/utils.ts
+++ b/apps/src/lib/utils.ts
@@ -225,4 +225,7 @@ export function prepareRaster(): void {
 	if (mapObjects) {
 		mapObjects.classList.add('to-raster');
 	}
+
+	// Resize the window to force a layout update.
+	window.dispatchEvent(new Event('resize'));
 }

--- a/fw-child/apps/app-map.php
+++ b/fw-child/apps/app-map.php
@@ -76,5 +76,10 @@ if ( isset( $assets['js'] ) && is_array( $assets['js'] ) && isset( $assets['js']
     }
 }
 ?>
+
+<script>
+    // URL encoder salt for the map app.
+    const URL_ENCODER_SALT = '<?php echo $GLOBALS['vars']['url_encoder_salt']; ?>';
+</script>
 </body>
 </html>

--- a/fw-child/apps/app-map.php
+++ b/fw-child/apps/app-map.php
@@ -78,8 +78,10 @@ if ( isset( $assets['js'] ) && is_array( $assets['js'] ) && isset( $assets['js']
 ?>
 
 <script>
-    // URL encoder salt for the map app.
-    const URL_ENCODER_SALT = '<?php echo $GLOBALS['vars']['url_encoder_salt']; ?>';
+  // URL encoder salt for the map app.
+  window.URL_ENCODER_SALT = '<?php echo htmlspecialchars($GLOBALS['vars']['url_encoder_salt'], ENT_QUOTES); ?>';
+  // DATA URL for the map app.
+  window.DATA_URL = '<?php echo htmlspecialchars($GLOBALS['vars']['data_url'], ENT_QUOTES); ?>';
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Description
- Added functions encodeUrl for the server.
- Added logic to fetch the Server API to generate the map.
- Prepared logic for the DownloadMap link
- Added $.fn.prepare_ruster() function for the server to remove extra divs.
-  Added id to certain divs that will be used by  $.fn.prepare_ruster().

## Related ticket
https://rm.ewdev.ca/issues/81981

## To do
- Create the link to the download version of the map.
- Dynamically retrieve Salt and server URL  values to generate encodedUrl and link to the server API.
