### PR TITLE
Refs #85535: Several pins are shown when clicking on the Recent location and clicking on another region on the map

### DIFF
--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -70,8 +70,16 @@ export default function SearchControl({
 
 	const handleLocationChange = useCallback(
 		(title: string, latlng: L.LatLng) => {
+
+			// clear all existing markers from the map
+			map.eachLayer(layer => {
+				if (layer instanceof L.Marker) {
+					map.removeLayer(layer);
+				}
+			});
 			map.setView(latlng, SEARCH_DEFAULT_ZOOM);
 
+			// Save recent location
 			dispatch(
 				addRecentLocation({
 					id: `${latlng?.lat}|${latlng?.lng}`,

--- a/apps/src/hooks/use-interactive-map-events.tsx
+++ b/apps/src/hooks/use-interactive-map-events.tsx
@@ -60,6 +60,13 @@ export const useInteractiveMapEvents = (
 			return;
 		}
 
+		// clear all existing markers from the map
+		map.eachLayer(layer => {
+			if (layer instanceof L.Marker) {
+				map.removeLayer(layer);
+			}
+		});
+
 		// a single marker is allowed at a time
 		if (markerRef.current) {
 			markerRef.current.removeFrom(map);


### PR DESCRIPTION
## Description
Clear pins before applying new ones on:
- Map Click
- Map Search
- Click on one of the recent location.

## Related ticket
https://rm.ewdev.ca/issues/85535