### PR TITLE
81973--continuation:social share buttons, and bug fixes

### DIFF
--- a/apps/package-lock.json
+++ b/apps/package-lock.json
@@ -39,6 +39,7 @@
         "react-dom": "^18.3.1",
         "react-leaflet": "^4.2.1",
         "react-redux": "^9.2.0",
+        "react-share": "^5.2.2",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
         "validator": "^13.12.0"
@@ -5437,6 +5438,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -7728,6 +7735,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==",
+      "dependencies": {
+        "debug": "^2.1.3"
+      }
+    },
+    "node_modules/jsonp/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/jsonp/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -8806,6 +8836,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-share": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/react-share/-/react-share-5.2.2.tgz",
+      "integrity": "sha512-z0nbOX6X6vHHWAvXduNkYeJUKTKNpKM5Xpmc5a2BxjJhUWl+sE7AsSEMmYEUj2DuDjZr5m7KFIGF0sQPKcUN6w==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.3.2",
+        "jsonp": "^0.2.1"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || ^19"
       }
     },
     "node_modules/react-style-singleton": {

--- a/apps/package.json
+++ b/apps/package.json
@@ -45,6 +45,7 @@
     "react-dom": "^18.3.1",
     "react-leaflet": "^4.2.1",
     "react-redux": "^9.2.0",
+    "react-share": "^5.2.2",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
     "validator": "^13.12.0"

--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -27,7 +27,7 @@ import { useClimateVariable } from "@/hooks/use-climate-variable";
 /**
  * MapHeader component, displays the header for the map with breadcrumbs and buttons for extra information.
  */
-const MapHeader: React.FC<MapInfoProps> = ({ data }): React.ReactElement => {
+const MapHeader: React.FC<MapInfoProps> = ({ data = null }): React.ReactElement => {
 	const [shareInfo, setShareInfo] = useState<boolean>(false);
 	const [downloadInfo, setDownloadInfo] = useState<boolean>(false);
 	const [panelProps, setPanelProps] = useState<
@@ -36,6 +36,7 @@ const MapHeader: React.FC<MapInfoProps> = ({ data }): React.ReactElement => {
 	const { togglePanel } = useAnimatedPanel();
 
 	const { locale } = useLocale();
+	const dataset = useAppSelector((state) => state.map.dataset);
 
 	const ref = useRef<HTMLDivElement>(null);
 
@@ -69,11 +70,12 @@ const MapHeader: React.FC<MapInfoProps> = ({ data }): React.ReactElement => {
 	};
 
 	/**
-	 * Toggles the visibility of the Variable Details panel.
-	 */
-	const toggleVariableDetailsPanel = () => {
-		togglePanel(<VariableDetailsPanel mapInfo={data} />, panelProps);
-	};
+	* Toggles the visibility of the Variable Details panel.
+	*/
+const toggleVariableDetailsPanel = () => {
+	if (!data) return;
+	togglePanel(<VariableDetailsPanel mapInfo={data} />, panelProps);
+};
 
 	return (
 		<>
@@ -98,7 +100,7 @@ const MapHeader: React.FC<MapInfoProps> = ({ data }): React.ReactElement => {
 			<DownloadMapModal
 				isOpen={downloadInfo}
 				onClose={toggleDownloadInfo}
-				title={data?.dataset?.[0]?.title?.[locale] ?? ''}
+				title={data?.dataset?.[0]?.title?.[locale] || dataset?.title?.[locale] || ''}
 			/>
 		</>
 	);
@@ -114,6 +116,7 @@ const Breadcrumbs: React.FC<{ onClick: () => void }> = ({
 	const { __ } = useI18n();
 	const { locale } = useLocale();
 	const dataset = useAppSelector((state) => state.map.dataset);
+	const variableList = useAppSelector((state) => state.map.variableList);
 	const { climateVariable } = useClimateVariable();
 
 	const datasetName = useMemo(() => {
@@ -127,10 +130,16 @@ const Breadcrumbs: React.FC<{ onClick: () => void }> = ({
 		if (climateVariable && climateVariable.toObject().postId) {
 			return climateVariable.getTitle() || '';
 		}
+		
+		// If no explicit climate variable selection, but we have variableList data,
+		// show the first variable as a fallback
+		if (variableList && variableList.length > 0) {
+			return variableList[0].title || '';
+		}
 
-		// Don't show anything if no variable is explicitly selected
+		// Don't show anything if we can't determine the variable
 		return '';
-	}, [climateVariable]);
+	}, [climateVariable, variableList]);
 
 	return (
 		<div className="flex items-center gap-2 breadcrumb">

--- a/apps/src/components/map-info/share-map-modal.tsx
+++ b/apps/src/components/map-info/share-map-modal.tsx
@@ -34,6 +34,10 @@ const ShareMapModal: React.FC<{
 
 	// Get the URL sync state to ensure URL parameters are loaded
 	const isUrlSyncInitialized = useAppSelector((state) => state.urlSync.isInitialized);
+	
+	// Get the climate variable data to use in the share title
+	const climateVariable = useAppSelector((state) => state.climateVariable.data);
+	const variableTitle = climateVariable?.title || __('Climate Data Map');
 
 	useEffect(() => {
 		if (isOpen && typeof window !== 'undefined') {
@@ -91,7 +95,7 @@ const ShareMapModal: React.FC<{
 					<ModalSectionBlockDescription>
 						{__('Clicking on icons will launch a new window.')}
 					</ModalSectionBlockDescription>
-					<SocialShareButtons />
+					<SocialShareButtons url={currentUrl} title={variableTitle} />
 				</ModalSectionBlock>
 			</ModalSection>
 		</Modal>

--- a/apps/src/components/map-wrapper.tsx
+++ b/apps/src/components/map-wrapper.tsx
@@ -16,7 +16,7 @@ const MapWrapper = () => {
 
 	return (
 		<div className="relative flex-1">
-			{mapInfo && <MapHeader data={mapInfo}/>}
+			<MapHeader data={mapInfo}/>
 			{climateVariable?.renderMap()}
 		</div>
 	);

--- a/apps/src/components/social-share-buttons.tsx
+++ b/apps/src/components/social-share-buttons.tsx
@@ -4,13 +4,49 @@
  */
 
 import { useI18n } from '@wordpress/react-i18n';
-import { FacebookShareButton, TwitterShareButton, LinkedinShareButton, EmailShareButton, FacebookIcon, TwitterIcon, LinkedinIcon, EmailIcon } from "react-share";
+import { FacebookShareButton, TwitterShareButton, LinkedinShareButton, EmailShareButton } from "react-share";
 import { MultilingualField } from '@/types/types';
 import { useLocale } from '@/hooks/use-locale';
 
 interface SocialShareButtonsProps {
 	url?: string;
 	title?: string | MultilingualField;
+}
+
+// SVG Icon Components
+function FacebookIcon() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="blue" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+            <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"></path>
+        </svg>
+    );
+}
+
+function TwitterIcon() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="blue" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+            <path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z"></path>
+        </svg>
+    );
+}
+
+function LinkedinIcon() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="blue" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+            <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path>
+            <rect width="4" height="12" x="2" y="9"></rect>
+            <circle cx="4" cy="4" r="2"></circle>
+        </svg>
+    );
+}
+
+function EmailIcon() {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="blue" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-6 w-6">
+            <rect width="20" height="16" x="2" y="4" rx="2"></rect>
+            <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path>
+        </svg>
+    );
 }
 
 /**
@@ -40,7 +76,7 @@ export function SocialShareButtons({
 	};
 	
 	// Prepare description text
-	const description = __('Check out this climate data map');
+	const description = __('Check out the Canadian climate data map');
 	const stringTitle = getStringTitle();
 
 	return (
@@ -52,7 +88,7 @@ export function SocialShareButtons({
 					className="hover:opacity-80"
 					aria-label={__('Share on Facebook (opens in a new tab)')}
 				>
-					<FacebookIcon size={32} round />
+					<FacebookIcon />
 				</FacebookShareButton>
 			</li>
 			<li className="social-share-buttons__list-item">
@@ -63,7 +99,7 @@ export function SocialShareButtons({
 					className="hover:opacity-80"
 					aria-label={__('Share on Twitter (opens in a new tab)')}
 				>
-					<TwitterIcon size={32} round />
+					<TwitterIcon />
 				</TwitterShareButton>
 			</li>
 			<li className="social-share-buttons__list-item">
@@ -72,7 +108,7 @@ export function SocialShareButtons({
 					className="hover:opacity-80"
 					aria-label={__('Share on LinkedIn (opens in a new tab)')}
 				>
-					<LinkedinIcon size={32} round />
+					<LinkedinIcon />
 				</LinkedinShareButton>
 			</li>
 			<li className="social-share-buttons__list-item">
@@ -81,9 +117,9 @@ export function SocialShareButtons({
 					subject={stringTitle}
 					body={description}
 					className="hover:opacity-80"
-					aria-label={__('Share via Email (opens in a new tab)')}
+					aria-label={__('Share via Email (opens in the same tab)')}
 				>
-					<EmailIcon size={32} round />
+					<EmailIcon />
 				</EmailShareButton>
 			</li>
 		</ul>

--- a/apps/src/components/social-share-buttons.tsx
+++ b/apps/src/components/social-share-buttons.tsx
@@ -1,73 +1,90 @@
 /**
- * @description Component to render a list of social media share buttons. The button links
- * are placehodlers currently, can be changed in this component.
+ * @description Component to render a list of social media share buttons
+ * using react-share for proper sharing functionality.
  */
 
-import { Facebook, Linkedin, Mail, Twitter } from 'lucide-react';
 import { useI18n } from '@wordpress/react-i18n';
+import { FacebookShareButton, TwitterShareButton, LinkedinShareButton, EmailShareButton, FacebookIcon, TwitterIcon, LinkedinIcon, EmailIcon } from "react-share";
+import { MultilingualField } from '@/types/types';
+import { useLocale } from '@/hooks/use-locale';
+
+interface SocialShareButtonsProps {
+	url?: string;
+	title?: string | MultilingualField;
+}
 
 /**
  * SocialShareButtons component
- * @description Renders a list of social media icons that allow sharing content on
- * different platforms. Each link opens in a new tab and includes appropriate
- * accessibility labels.
+ * @description Renders a list of social media buttons that allow sharing content on
+ * different platforms using the react-share library.
  */
-export function SocialShareButtons(): JSX.Element {
+export function SocialShareButtons({ 
+	url = window.location.href, 
+	title = document.title 
+}: SocialShareButtonsProps): JSX.Element {
 	const { __ } = useI18n();
-
-	// Placeholder URLs for social sharing links
-	const shareUrls = {
-		facebook: '#', // Placeholder for Facebook share URL
-		twitter: '#', // Placeholder for Twitter share URL
-		linkedin: '#', // Placeholder for LinkedIn share URL
-		mail: '#', // Placeholder for Email share URL
+	const { locale } = useLocale();
+	
+	// Process the title to ensure it's a string in the current language
+	const getStringTitle = (): string => {
+		if (typeof title === 'string') {
+			return title;
+		} else if (title && typeof title === 'object') {
+			if (locale === 'fr' && title.fr) {
+				return title.fr;
+			}
+			
+			return title.en;
+		}
+		return document.title;
 	};
+	
+	// Prepare description text
+	const description = __('Check out this climate data map');
+	const stringTitle = getStringTitle();
 
 	return (
 		<ul className="social-share-buttons flex gap-2">
 			<li className="social-share-buttons__list-item">
-				<a
-					href={shareUrls.facebook}
-					target="_blank"
-					rel="noopener noreferrer"
+				<FacebookShareButton 
+					url={url}
+					hashtag="#ClimateData"
+					className="hover:opacity-80"
 					aria-label={__('Share on Facebook (opens in a new tab)')}
-					className="hover:text-blue-700"
 				>
-					<Facebook color="blue" className="h-6 w-6" />
-				</a>
+					<FacebookIcon size={32} round />
+				</FacebookShareButton>
 			</li>
 			<li className="social-share-buttons__list-item">
-				<a
-					href={shareUrls.twitter}
-					target="_blank"
-					rel="noopener noreferrer"
+				<TwitterShareButton
+					url={url}
+					title={`${stringTitle}\n${description}: `}
+					hashtags={["ClimateData"]}
+					className="hover:opacity-80"
 					aria-label={__('Share on Twitter (opens in a new tab)')}
-					className="hover:text-blue-700"
 				>
-					<Twitter color="blue" className="h-6 w-6" />
-				</a>
+					<TwitterIcon size={32} round />
+				</TwitterShareButton>
 			</li>
 			<li className="social-share-buttons__list-item">
-				<a
-					href={shareUrls.linkedin}
-					target="_blank"
-					rel="noopener noreferrer"
+				<LinkedinShareButton
+					url={url}
+					className="hover:opacity-80"
 					aria-label={__('Share on LinkedIn (opens in a new tab)')}
-					className="hover:text-blue-700"
 				>
-					<Linkedin color="blue" className="h-6 w-6" />
-				</a>
+					<LinkedinIcon size={32} round />
+				</LinkedinShareButton>
 			</li>
 			<li className="social-share-buttons__list-item">
-				<a
-					href={shareUrls.mail}
-					target="_blank"
-					rel="noopener noreferrer"
+				<EmailShareButton
+					url={url}
+					subject={stringTitle}
+					body={description}
+					className="hover:opacity-80"
 					aria-label={__('Share via Email (opens in a new tab)')}
-					className="hover:text-blue-700"
 				>
-					<Mail color="blue" className="h-6 w-6" />
-				</a>
+					<EmailIcon size={32} round />
+				</EmailShareButton>
 			</li>
 		</ul>
 	);

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -333,7 +333,7 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
  * Props for the MapInfo component.
  */
 export interface MapInfoProps {
-	data: MapInfoData;
+	data: MapInfoData | null;
 }
 
 /**


### PR DESCRIPTION
## Description

Continuation of
#422 

- [x] Bug: Map header component disappears in initial state
- [x] Bug: Pasted (shared) url misses variable name in Breadcrumbs on init
- [x] Implement social sharing buttons. Use [React-share](https://www.npmjs.com/package/react-share) package. Since every platform has its own url params, I prototyped something, but soon found that having this dedicated package is less headache.

**Note:** Run npm install in `/apps` directory to install `react-share`

**Big Note ⚠️ :** Linked-in due to its API limitations does not populate the post content and only opens the share panel and a new post.

Here are some [StackOverflow comments](https://stackoverflow.com/a/10737122/13507727).

## Related ticket
https://rm.ewdev.ca/issues/81973