### PR TITLE
refs #86465: Remove seasons option from some variables

### DIFF
--- a/apps/src/components/download/step-additional-details.tsx
+++ b/apps/src/components/download/step-additional-details.tsx
@@ -233,9 +233,10 @@ const StepAdditionalDetails = React.forwardRef<StepComponentRef>((_, ref) => {
 				value={climateVariable?.getFrequency() ?? undefined}
 				onValueChange={setFrequency}
 				className={"sm:w-64 mb-4"}
+				downloadType={climateVariable?.getDownloadType() ?? undefined}
 			/>
 
-			{isDownloadTypeAnalyzed
+			{!isDownloadTypeAnalyzed
 				&& averagingOptions.length > 0
 				&& climateVariable?.getFrequency() !== FrequencyType.DAILY
 				&& <RadioGroupFactory

--- a/apps/src/components/frequency-select.tsx
+++ b/apps/src/components/frequency-select.tsx
@@ -10,6 +10,7 @@ import {
 	SelectValue
 } from "@/components/ui/select";
 import {
+	DownloadType,
 	FrequencyConfig,
 	FrequencyType,
 } from "@/types/climate-variable-interface";
@@ -25,6 +26,7 @@ interface FrequencySelectProps {
 	tooltip?: React.ReactNode;
 	onValueChange: (value: string) => void;
 	className?: string | undefined;
+	downloadType?: DownloadType;
 }
 
 const FrequencySelect = ({
@@ -35,7 +37,8 @@ const FrequencySelect = ({
 	placeholder,
 	tooltip,
 	onValueChange,
-	className
+	className,
+	downloadType,
 }: FrequencySelectProps) => {
 	const { __ } = useI18n();
 
@@ -85,6 +88,61 @@ const FrequencySelect = ({
 		{ label: __('Winter'), value: 'winter' },
 	]
 
+	const renderMonthlyOptions = () => {
+		if (!hasMonths && !hasAllMonths) {
+			return null;
+		}
+
+		if (downloadType === DownloadType.ANALYZED) {
+			return (
+				<SelectItem value={FrequencyType.MONTHLY}>
+					{__('Monthly')}
+				</SelectItem>
+			);
+		} else {
+			return (
+				<SelectGroup>
+					<SelectLabel className={'pl-2'}>{__('Monthly')}</SelectLabel>
+					{hasAllMonths && (
+						<SelectItem value={FrequencyType.ALL_MONTHS} className={'pl-4'}>
+							{__('All months')}
+						</SelectItem>
+					)}
+					{months.map((option) => (
+						<SelectItem key={option.value} value={option.value} className={'pl-4'}>
+							{option.label}
+						</SelectItem>
+					))}
+				</SelectGroup>
+			);
+		}
+	}
+
+	const renderSeasonalOptions = () => {
+		if (!hasSeasons) {
+			return null;
+		}
+
+		if (downloadType === DownloadType.ANALYZED) {
+			return (
+				<SelectItem value={FrequencyType.SEASONAL}>
+					{__('Seasonal')}
+				</SelectItem>
+			);
+		} else {
+			return (
+				<SelectGroup>
+					<SelectLabel className={'pl-2'}>{__('Seasonal')}</SelectLabel>
+					{seasons.map((option) => (
+						<SelectItem key={option.value} value={option.value} className={'pl-4'}>
+							{option.label}
+						</SelectItem>
+					))}
+				</SelectGroup>
+			);
+		}
+	}
+
 	const FrequencyOptions = () => (
 		<SelectContent>
 			{hasAnnual && <SelectItem value={FrequencyType.ANNUAL}>
@@ -96,25 +154,8 @@ const FrequencySelect = ({
 			{hasDaily && <SelectItem value={FrequencyType.DAILY}>
 				{__('Daily')}
 			</SelectItem>}
-			{(hasMonths || hasAllMonths) && <SelectGroup>
-				<SelectLabel className={'pl-2'}>{__('Monthly')}</SelectLabel>
-				{hasAllMonths && <SelectItem value={FrequencyType.ALL_MONTHS} className={'pl-4'}>
-					{__('All months')}
-				</SelectItem>}
-				{months.map((option) => (
-					<SelectItem key={option.value} value={option.value} className={'pl-4'}>
-						{option.label}
-					</SelectItem>
-				))}
-			</SelectGroup>}
-			{hasSeasons && <SelectGroup>
-				<SelectLabel className={'pl-2'}>{__('Seasonal')}</SelectLabel>
-				{seasons.map((option) => (
-					<SelectItem key={option.value} value={option.value} className={'pl-4'}>
-						{option.label}
-					</SelectItem>
-				))}
-			</SelectGroup>}
+			{renderMonthlyOptions()}
+			{renderSeasonalOptions()}
 		</SelectContent>
 	)
 

--- a/apps/src/config/climate-variables.config.ts
+++ b/apps/src/config/climate-variables.config.ts
@@ -1335,7 +1335,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 		frequencyConfig: {
 			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
 			[FrequencyType.ALL_MONTHS]: FrequencyDisplayModeOption.DOWNLOAD,
-			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.ALWAYS,
+			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.DOWNLOAD,
 			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
 		},
 		averagingOptions: [
@@ -1420,6 +1420,12 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 				label: "22 ºC",
 			},
 		],
+		frequencyConfig: {
+			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
+			[FrequencyType.ALL_MONTHS]: FrequencyDisplayModeOption.ALWAYS,
+			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.DOWNLOAD,
+			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
+		},
 		averagingOptions: [
 			AveragingType.ALL_YEARS,
 			AveragingType.THIRTY_YEARS,

--- a/apps/src/config/climate-variables.config.ts
+++ b/apps/src/config/climate-variables.config.ts
@@ -9,7 +9,6 @@ import {
 	InteractiveRegionOption,
 } from "@/types/climate-variable-interface";
 
-
 export const ClimateVariables: ClimateVariableConfigInterface[] = [
 	/** Test variable */
 	{
@@ -1334,7 +1333,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 		threshold: "hddheat_18",
 		frequencyConfig: {
 			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
-			[FrequencyType.ALL_MONTHS]: FrequencyDisplayModeOption.DOWNLOAD,
+			[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.DOWNLOAD,
 			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.DOWNLOAD,
 			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
 		},
@@ -1422,7 +1421,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 		],
 		frequencyConfig: {
 			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
-			[FrequencyType.ALL_MONTHS]: FrequencyDisplayModeOption.ALWAYS,
+			[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.ALWAYS,
 			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.DOWNLOAD,
 			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
 		},

--- a/apps/src/config/climate-variables.config.ts
+++ b/apps/src/config/climate-variables.config.ts
@@ -801,6 +801,9 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 		threshold: "cddcold_18",
 		frequencyConfig: {
 			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
+			[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.DOWNLOAD,
+			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.DOWNLOAD,
+			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
 		},
 		averagingOptions: [
 			AveragingType.ALL_YEARS,
@@ -909,13 +912,6 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 			AveragingType.ALL_YEARS,
 			AveragingType.THIRTY_YEARS,
 		],
-		frequencyConfig: {
-			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
-			[FrequencyType.ALL_MONTHS]: FrequencyDisplayModeOption.DOWNLOAD,
-			[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.ALWAYS,
-			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.DOWNLOAD,
-			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
-		},
 		unit: "days",
 		temporalThresholdConfig: {
 			thresholds: {
@@ -1180,6 +1176,8 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 		],
 		frequencyConfig: {
 			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
+			[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.DOWNLOAD,
+			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.DOWNLOAD,
 			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
 		},
 		averagingOptions: [
@@ -1419,12 +1417,6 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 				label: "22 ºC",
 			},
 		],
-		frequencyConfig: {
-			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
-			[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.ALWAYS,
-			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.DOWNLOAD,
-			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
-		},
 		averagingOptions: [
 			AveragingType.ALL_YEARS,
 			AveragingType.THIRTY_YEARS,
@@ -1519,6 +1511,12 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 				label: "20 mm",
 			},
 		],
+		frequencyConfig: {
+			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
+			[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.ALWAYS,
+			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.ALWAYS,
+			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
+		},
 		averagingOptions: [
 			AveragingType.ALL_YEARS,
 			AveragingType.THIRTY_YEARS,

--- a/apps/src/lib/raster-analyze-climate-variable.tsx
+++ b/apps/src/lib/raster-analyze-climate-variable.tsx
@@ -25,7 +25,6 @@ class RasterAnalyzeClimateVariable extends RasterPrecalculatedClimateVariable {
 			? ClimateVariableBase.prototype.getFrequencyConfig.call(this)
 			: {
 				[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
-				[FrequencyType.ALL_MONTHS]: FrequencyDisplayModeOption.DOWNLOAD,
 				[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.ALWAYS,
 				[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.ALWAYS,
 				[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,

--- a/apps/src/lib/raster-analyze-climate-variable.tsx
+++ b/apps/src/lib/raster-analyze-climate-variable.tsx
@@ -26,7 +26,7 @@ class RasterAnalyzeClimateVariable extends RasterPrecalculatedClimateVariable {
 			: {
 				[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
 				[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.ALWAYS,
-				[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.ALWAYS,
+				[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.DOWNLOAD,
 				[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
 			};
 	}


### PR DESCRIPTION
## Description

- Forced display of "Seasonal" and "Monthly" options in the Download section for analyzed variables, instead of displaying individual seasons (e.g. Summer) or months.
- The following variable configs have been updated as well:
  - Heating Degree Days
  - Tropical Nights
  - Cooling Degree Days
  - Freeze-Thaw Cycles
  - Wet-days
