### PR TITLE
Refs: 82008: Sets url params for download app and navigate to step 2 if variable is set in the url

### DIFF
--- a/apps/src/app/store.ts
+++ b/apps/src/app/store.ts
@@ -13,6 +13,7 @@ import climateVariableReducer from '@/store/climate-variable-slice';
 import mapReducer from '@/features/map/map-slice';
 import downloadReducer from '@/features/download/download-slice';
 import urlSyncReducer from '@/features/url-sync/url-sync-slice';
+import downloadUrlSyncReducer from '@/features/download/download-url-sync-slice';
 
 // API Slices and Reducers - Fetch requests that are going to populate the store
 import { wpApiSlice } from '@/services/wp-node';
@@ -35,6 +36,7 @@ export const store = configureStore({
 		map: mapReducer,
 		download: downloadReducer,
 		urlSync: urlSyncReducer,
+		downloadUrlSync: downloadUrlSyncReducer,
 		[wpApiSlice.reducerPath]: wpApiSlice.reducer,
 	},
 	middleware: (getDefaultMiddleware) =>

--- a/apps/src/components/map-info/download-map-modal.tsx
+++ b/apps/src/components/map-info/download-map-modal.tsx
@@ -7,6 +7,8 @@
 import React, { useMemo, useState } from 'react';
 import { useI18n } from '@wordpress/react-i18n';
 import { Download, ExternalLink } from 'lucide-react';
+import { useAppSelector } from '@/app/hooks';
+import { WP_API_DOMAIN } from '@/lib/constants';
 
 // components
 import Modal from '@/components/ui/modal';
@@ -25,6 +27,10 @@ const DownloadMapModal: React.FC<{
 }> = ({ isOpen, onClose, title }) => {
 	const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
 	const [isGenerating, setIsGenerating] = useState<boolean>(false);
+	
+	// Get dataset and variable information for download URL
+	const dataset = useAppSelector((state) => state.map.dataset);
+	const climateVariableData = useAppSelector((state) => state.climateVariable.data);
 
 	const { __ } = useI18n();
 
@@ -50,6 +56,15 @@ const DownloadMapModal: React.FC<{
 			}
 		}
 	};
+
+	// Generate download section URL with dataset and variable parameters
+	const getDownloadUrl = useMemo(() => {
+		if (!dataset || !climateVariableData || !climateVariableData.id) {
+			return `${WP_API_DOMAIN}/download-app/`;
+		}
+		
+		return `${WP_API_DOMAIN}/download-app/?dataset=${encodeURIComponent(dataset.term_id.toString())}&var=${encodeURIComponent(climateVariableData.id)}`;
+	}, [dataset, climateVariableData]);
 
 	const buttonText = useMemo(() => {
 		if (isGenerating) {
@@ -102,7 +117,7 @@ const DownloadMapModal: React.FC<{
 						)}
 					</ModalSectionBlockDescription>
 					<a
-						href="#"
+						href={getDownloadUrl}
 						target="_blank"
 						aria-label={__(
 							'Go to download sections (opens in a new tab)'

--- a/apps/src/context/download-provider.tsx
+++ b/apps/src/context/download-provider.tsx
@@ -38,6 +38,7 @@
  */
 
 import React, { createContext, useState, useCallback, useRef, useEffect } from 'react';
+import { useDownloadUrlSync } from '@/hooks/use-download-url-sync';
 import { useAppSelector, useAppDispatch } from '@/app/hooks';
 import { TaxonomyData } from '@/types/types';
 import { StepComponentRef } from '@/types/download-form-interface';
@@ -60,9 +61,14 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({
 	children,
 }) => {
 	const { climateVariable } = useClimateVariable();
+	// Initialize URL sync
+	useDownloadUrlSync();
 
 	const [steps, setSteps] = useState<typeof STEPS>([...STEPS]);
-	const [currentStep, setCurrentStep] = useState<number>(1);
+	// Start at step 2 if URL has variable parameter
+	const params = new URLSearchParams(window.location.search);
+	const hasVariable = params.has('var');
+	const [currentStep, setCurrentStep] = useState<number>(hasVariable ? 2 : 1);
 	const dataset = useAppSelector((state) => state.download.dataset);
 	const dispatch = useAppDispatch();
 

--- a/apps/src/features/download/download-url-sync-slice.ts
+++ b/apps/src/features/download/download-url-sync-slice.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+interface DownloadUrlSyncState {
+	isInitialized: boolean;
+	isLoaded: boolean;
+}
+
+const initialState: DownloadUrlSyncState = {
+	isInitialized: false,
+	isLoaded: false
+};
+
+const downloadUrlSyncSlice = createSlice({
+	name: "downloadUrlSync",
+	initialState,
+	reducers: {
+		initializeDownloadUrlSync: (state) => {
+			state.isInitialized = true;
+		},
+		setDownloadUrlParamsLoaded: (state, action: PayloadAction<boolean>) => {
+			state.isLoaded = action.payload;
+		}
+	}
+});
+
+export const { initializeDownloadUrlSync, setDownloadUrlParamsLoaded } = downloadUrlSyncSlice.actions;
+export default downloadUrlSyncSlice.reducer;

--- a/apps/src/hooks/use-download-url-sync.ts
+++ b/apps/src/hooks/use-download-url-sync.ts
@@ -1,0 +1,146 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import { setDataset } from '@/features/download/download-slice';
+import { setClimateVariable } from '@/store/climate-variable-slice';
+import { ClimateVariables } from '@/config/climate-variables.config';
+import { ClimateVariableConfigInterface } from '@/types/climate-variable-interface';
+import { fetchTaxonomyData, fetchPostsData } from '@/services/services';
+import { initializeDownloadUrlSync, setDownloadUrlParamsLoaded } from '@/features/download/download-url-sync-slice';
+import { normalizePostData } from '@/lib/format';
+
+/**
+ * Synchronizes download state with URL params
+ * Simpler than the map URL sync since we only need dataset and variable
+ */
+export const useDownloadUrlSync = () => {
+	const updateTimeoutRef = useRef<number | null>(null);
+	const urlProcessingCompleteRef = useRef<boolean>(false);
+	const dispatch = useAppDispatch();
+
+	// Get the URL sync state
+	const isInitialized = useAppSelector((state) => state.downloadUrlSync.isInitialized);
+	const dataset = useAppSelector((state) => state.download.dataset);
+	const climateVariableData = useAppSelector((state) => state.climateVariable.data);
+	
+	// Helper function to add parameters to URL
+	const addParamsToUrl = (
+		params: URLSearchParams
+	) => {
+		if (climateVariableData?.id) {
+			params.set('var', climateVariableData.id);
+		}
+		
+		if (dataset && dataset.term_id) {
+			params.set('dataset', dataset.term_id.toString());
+		}
+	};
+	
+	const updateUrlWithDebounce = useCallback(() => {
+		if (typeof window === 'undefined' || !isInitialized) return;
+		
+		if (updateTimeoutRef.current !== null) {
+			window.clearTimeout(updateTimeoutRef.current);
+		}
+		
+		updateTimeoutRef.current = window.setTimeout(() => {
+			const params = new URLSearchParams();
+			
+			addParamsToUrl(params);
+
+			// Update URL without navigation
+			const newUrl = `${window.location.pathname}?${params.toString()}`;
+			window.history.replaceState({}, '', newUrl);
+			
+			updateTimeoutRef.current = null;
+		}, 200);
+	}, [
+		climateVariableData,
+		dataset,
+		isInitialized
+	]);
+
+	useEffect(() => {
+		if (isInitialized || urlProcessingCompleteRef.current) return;
+		const params = new URLSearchParams(window.location.search);
+
+		dispatch(initializeDownloadUrlSync());
+
+		// Mark as NOT loaded until processing completes
+		dispatch(setDownloadUrlParamsLoaded(false));
+
+		// Process URL parameters
+		(async () => {
+			try {
+				const datasetParam = params.get('dataset');
+				const variableParam = params.get('var');
+				
+				if (datasetParam) {
+					const datasets = await fetchTaxonomyData('datasets', 'download');
+					
+					// Find dataset by term_id
+					const datasetParamNum = parseInt(datasetParam);
+					const matchedDataset = !isNaN(datasetParamNum) ? datasets.find(dataset => dataset.term_id === datasetParamNum) : null;
+					
+					if (matchedDataset) {
+						dispatch(setDataset(matchedDataset));
+						
+						if (variableParam) {
+							const variables = await fetchPostsData('variables', 'download', matchedDataset, {});
+							const normalizedVariables = await normalizePostData(variables, 'en');
+							
+							// Find the matching config
+							const matchedVariable = ClimateVariables.find(
+								(config) => config.id === variableParam
+							);
+							
+							if (matchedVariable) {
+								const matchingPostData = normalizedVariables.find(post => post.id === variableParam);
+								
+								if (matchingPostData) {
+									// Create a config that includes post data
+									const variableConfig: ClimateVariableConfigInterface = {
+										...matchedVariable,
+										postId: matchingPostData.postId,
+										title: matchingPostData.title
+									};
+									
+									dispatch(setClimateVariable(variableConfig));
+								} else {
+									// Set the variable without post data
+									dispatch(setClimateVariable(matchedVariable));
+								}
+							}
+						}
+					}
+				}
+				
+				// Mark URL parameters as loaded
+				urlProcessingCompleteRef.current = true;
+				dispatch(setDownloadUrlParamsLoaded(true));
+			} catch (error) {
+				console.error('Error processing URL parameters:', error);
+				urlProcessingCompleteRef.current = true;
+				dispatch(setDownloadUrlParamsLoaded(true));
+			}
+		})();
+	}, [dispatch, isInitialized]);
+
+	useEffect(() => {
+		if (!isInitialized) return;
+		updateUrlWithDebounce();
+	}, [
+		climateVariableData,
+		dataset,
+		updateUrlWithDebounce,
+		isInitialized
+	]);
+
+	// Clean up timeout on unmount
+	useEffect(() => {
+		return () => {
+			if (updateTimeoutRef.current !== null) {
+				window.clearTimeout(updateTimeoutRef.current);
+			}
+		};
+	}, []);
+};


### PR DESCRIPTION
## Description

When clicking the link from the Map application in `download-map-modal.tsx` to the Download app, the selected dataset and variable will be pre-selected and the user should automatically land on the 2nd step (variable selection).

Passes dataset (step 1) and variable type (step 2) from the URL, when present.

## Related Ticket:
https://rm.ewdev.ca/issues/82008