### PR TITLE
Refs #86862 and #80032: Search icon and fixed search enter behaviour.

### DIFF
--- a/apps/src/Global.css
+++ b/apps/src/Global.css
@@ -184,8 +184,12 @@
 }
 
 /* replace search icon image with an svg icon */
-.leaflet-container .leaflet-control-search .search-button::before {
+.leaflet-container .leaflet-control-search .search-button {
+	display:none;
+}
+.leaflet-container .leaflet-control-search::after {
 	content: "";
+	margin-left: 10px;
 	display: block;
 	width: 16px;
 	height: 16px;

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -186,13 +186,23 @@ export default function SearchControl({
 				return `<div>${buildLocationTitle(item)}</div>`;
 			},
 			locationNotFound: async function() {
+				// If the list of suggestions is still shown, no error message is shown.
+				// See #86862
+				if (Object.keys(this._recordsCache).length > 0) {
+					this.showTooltip(this._recordsCache)
+					return;
+				}
+				// Check if the coordinates are valid if the location is empty.
 				const latLng = isLatLong(this._input.value);
 				// If the coordinates are valid, move to that location.
 				if (latLng.lat && latLng.lng) {
+					// Fetch location data
 					const locationByCoords = await fetchLocationByCoords(latLng);
+					// Trigger show location.
 					this.showLocation(locationByCoords, locationByCoords.geo_id);
 				}
 				else {
+					// Show error alert.
 					this.showAlert();
 				}
 			},


### PR DESCRIPTION
## Description
Search button is now a decorative icon
If there are addresses available in search and the user presses enter without selecting an address, it will not show an error.
## Related ticket
https://rm.ewdev.ca/issues/86862
https://rm.ewdev.ca/issues/80032

