### PR TITLE
Refs: 82008: bug resolves for returning to previous steps

### DIFF
--- a/apps/src/features/download/download-slice.ts
+++ b/apps/src/features/download/download-slice.ts
@@ -21,6 +21,7 @@ export const initialState: DownloadState = {
 	email: '',
 	subscribe: false,
 	variableListLoading: false,
+	currentStep: 1,
 };
 
 // Create the slice
@@ -55,6 +56,13 @@ const downloadSlice = createSlice({
 		setVariableListLoading(state, action: PayloadAction<boolean>) {
 			state.variableListLoading = action.payload;
 		},
+		setCurrentStep(state, action: PayloadAction<number>) {
+			state.currentStep = action.payload;
+		},
+		resetVariableSelection(state) {
+			state.dataset = state.dataset; // Keep dataset
+			state.currentStep = 1;
+		},
 	},
 });
 
@@ -69,6 +77,8 @@ export const {
 	setEmail,
 	setSubscribe,
 	setVariableListLoading,
+	setCurrentStep,
+	resetVariableSelection,
 } = downloadSlice.actions;
 
 // Export reducer

--- a/apps/src/features/download/download-url-sync-slice.ts
+++ b/apps/src/features/download/download-url-sync-slice.ts
@@ -19,9 +19,17 @@ const downloadUrlSyncSlice = createSlice({
 		},
 		setDownloadUrlParamsLoaded: (state, action: PayloadAction<boolean>) => {
 			state.isLoaded = action.payload;
+		},
+		resetDownloadUrlSync: (state) => {
+			// Reset state but keep initialized flag to true
+			state.isLoaded = false;
 		}
 	}
 });
 
-export const { initializeDownloadUrlSync, setDownloadUrlParamsLoaded } = downloadUrlSyncSlice.actions;
+export const { 
+	initializeDownloadUrlSync, 
+	setDownloadUrlParamsLoaded,
+	resetDownloadUrlSync
+} = downloadUrlSyncSlice.actions;
 export default downloadUrlSyncSlice.reducer;

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -202,6 +202,7 @@ export interface DownloadState {
 	email: string;
 	subscribe: boolean;
 	variableListLoading: boolean;
+	currentStep: number;
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes reported issues by QA:
1. URL params are not cleared when returning to previous step (e.g., step 1)
2. If user navigates directly to the list then they cannot return to step 1
3. when user returns to step 1 and select another dataset then the dataset param is changed, but the variable is not cleared

## Work Summary

### Step Management:

* Added `currentStep` to Redux with actions to update/reset it for consistent step handling.
* `DownloadProvider` now syncs steps via Redux and clears the climate variable on step 1.

### URL Sync:

* URL params (`var`, `dataset`) now only appear after step 1 and are cleared when going back.

### State Cleanup:

* Added action to reset URL sync state without losing init status.
* Updated types to include `currentStep` for better type safety.

## Related ticket
https://rm.ewdev.ca/issues/82008
