### PR TITLE
Refs: 79162: remove drawer functionality from sidebar

### DIFF
--- a/apps/src/App.tsx
+++ b/apps/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
 					<AnimatedPanelProvider>
 						<SidebarProvider>
 							<AppSidebar />
-							<SidebarTrigger />
+							<SidebarTrigger className="md:hidden" />
 							<main className="flex flex-col h-screen">
 								<Header />
 								<MapWrapper />

--- a/apps/src/App.tsx
+++ b/apps/src/App.tsx
@@ -1,3 +1,4 @@
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { AppSidebar } from '@/components/app-sidebar';
 import { SidebarProvider } from '@/context/sidebar-provider';
 import Header from '@/components/header';
@@ -23,6 +24,7 @@ function App() {
 					<AnimatedPanelProvider>
 						<SidebarProvider>
 							<AppSidebar />
+							<SidebarTrigger />
 							<main className="flex flex-col h-screen">
 								<Header />
 								<MapWrapper />

--- a/apps/src/App.tsx
+++ b/apps/src/App.tsx
@@ -1,4 +1,3 @@
-import { SidebarTrigger } from '@/components/ui/sidebar';
 import { AppSidebar } from '@/components/app-sidebar';
 import { SidebarProvider } from '@/context/sidebar-provider';
 import Header from '@/components/header';
@@ -24,7 +23,6 @@ function App() {
 					<AnimatedPanelProvider>
 						<SidebarProvider>
 							<AppSidebar />
-							<SidebarTrigger />
 							<main className="flex flex-col h-screen">
 								<Header />
 								<MapWrapper />

--- a/apps/src/components/sidebar-menu-items/datasets.tsx
+++ b/apps/src/components/sidebar-menu-items/datasets.tsx
@@ -166,7 +166,7 @@ const DatasetsPanel: React.FC<InteractivePanelProps<TaxonomyData | null>> = ({
 	}
 
 	return (
-		<SidebarPanel id={slug} className="w-96">
+		<SidebarPanel id={slug} className="w-[--sidebar-width] md:w-96">
 			<Card className="h-full flex flex-col">
 				<CardHeader className="p-4 sticky top-0 bg-white z-10">
 					<CardTitle className="text-lg">

--- a/apps/src/components/sidebar-menu-items/variables.tsx
+++ b/apps/src/components/sidebar-menu-items/variables.tsx
@@ -14,7 +14,6 @@ import {
 	CardHeader,
 	CardTitle,
 } from '@/components/ui/card';
-import Grid from '@/components/ui/grid';
 import {
 	SidebarMenuButton,
 	SidebarMenuItem,
@@ -114,7 +113,7 @@ const VariablesPanel: React.FC<VariablesPanelProps> = ({
 	};
 
 	return (
-		<SidebarPanel id={slug} className="w-[36rem]">
+		<SidebarPanel id={slug} className="w-[--sidebar-width] md:w-[36rem]">
 			<Card className="border-0 shadow-none h-full flex flex-col">
 				<CardHeader className="p-4 sticky top-0 bg-white z-10">
 					<CardTitle className="text-lg">
@@ -125,7 +124,7 @@ const VariablesPanel: React.FC<VariablesPanelProps> = ({
 							'Here you can browse all the variables contained in the selected dataset.'
 						)}
 					</CardDescription>
-					<Grid columns={2} className="gap-4 mt-4">
+					<div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
 						<TaxonomyDropdownFilter
 							className="sm:w-52"
 							onFilterChange={handleVarTypeChange}
@@ -144,13 +143,13 @@ const VariablesPanel: React.FC<VariablesPanelProps> = ({
 							placeholder={__('All')}
 							value={filterValues.sector || ''}
 						/>
-					</Grid>
+					</div>
 					<div className="mt-6">
 						<VariableSearchFilter />
 					</div>
 				</CardHeader>
 				<CardContent className="p-4 pt-0 overflow-y-auto max-h-[calc(100vh-200px)] scrollbar-thin">
-					<Grid columns={2} className="gap-4">
+					<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
 						{dataset ? (
 							<VariableRadioCards
 								dataset={dataset}
@@ -160,11 +159,11 @@ const VariablesPanel: React.FC<VariablesPanelProps> = ({
 								onSelect={onSelect}
 							/>
 						) : (
-							<div className="col-span-2 p-4 text-center">
+							<div className="col-span-1 md:col-span-2 p-4 text-center">
 								{__('Please select a dataset first')}
 							</div>
 						)}
-					</Grid>
+					</div>
 				</CardContent>
 			</Card>
 		</SidebarPanel>

--- a/apps/src/components/ui/dropdown.tsx
+++ b/apps/src/components/ui/dropdown.tsx
@@ -84,7 +84,7 @@ const DropdownGeneric = <T extends string | undefined>(
 	};
 
 	return (
-		<div ref={ref} className={cn('dropdown z-50', className)}>
+		<div ref={ref} className={cn('dropdown z-30', className)}>
 			{label && <ControlTitle title={label} tooltip={tooltip} />}
 			<Select value={value} onValueChange={handleValueChanged}>
 				<SelectTrigger className="w-full focus:ring-0 focus:ring-offset-0 text-cdc-black [&>svg]:text-brand-blue [&>svg]:opacity-100">

--- a/apps/src/components/ui/sidebar.tsx
+++ b/apps/src/components/ui/sidebar.tsx
@@ -1,13 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { VariantProps, cva } from 'class-variance-authority';
-import { X as CloseIcon, PanelLeft } from 'lucide-react';
+import { X as CloseIcon } from 'lucide-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useI18n } from '@wordpress/react-i18n';
 
 import { useSidebar } from '@/hooks/use-sidebar';
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { Sheet, SheetContent } from '@/components/ui/sheet';
@@ -144,32 +143,6 @@ const Sidebar = React.forwardRef<
 	}
 );
 Sidebar.displayName = 'Sidebar';
-
-const SidebarTrigger = React.forwardRef<
-	React.ElementRef<typeof Button>,
-	React.ComponentProps<typeof Button>
->(({ className, onClick, ...props }, ref) => {
-	const { toggleSidebar } = useSidebar();
-
-	return (
-		<Button
-			ref={ref}
-			data-sidebar="trigger"
-			variant="ghost"
-			size="icon"
-			className={cn('h-7 w-7', className)}
-			onClick={(event) => {
-				onClick?.(event);
-				toggleSidebar();
-			}}
-			{...props}
-		>
-			<PanelLeft />
-			<span className="sr-only">Toggle Sidebar</span>
-		</Button>
-	);
-});
-SidebarTrigger.displayName = 'SidebarTrigger';
 
 const SidebarRail = React.forwardRef<
 	HTMLButtonElement,
@@ -770,5 +743,4 @@ export {
 	SidebarPanel,
 	SidebarRail,
 	SidebarSeparator,
-	SidebarTrigger,
 };

--- a/apps/src/components/ui/sidebar.tsx
+++ b/apps/src/components/ui/sidebar.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { VariantProps, cva } from 'class-variance-authority';
-import { X as CloseIcon } from 'lucide-react';
+import { X as CloseIcon, PanelLeft } from 'lucide-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useI18n } from '@wordpress/react-i18n';
 
 import { useSidebar } from '@/hooks/use-sidebar';
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { Sheet, SheetContent } from '@/components/ui/sheet';
@@ -778,4 +779,5 @@ export {
 	SidebarPanel,
 	SidebarRail,
 	SidebarSeparator,
+	SidebarTrigger,
 };

--- a/apps/src/components/ui/sidebar.tsx
+++ b/apps/src/components/ui/sidebar.tsx
@@ -71,7 +71,7 @@ const Sidebar = React.forwardRef<
 					<SheetContent
 						data-sidebar="sidebar"
 						data-mobile="true"
-						className="w-[--sidebar-width] bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+						className="w-[--sidebar-width] bg-sidebar p-2 text-sidebar-foreground [&>button]:hidden"
 						style={
 							{
 								'--sidebar-width': SIDEBAR_WIDTH_MOBILE,
@@ -716,6 +716,8 @@ const SidebarPanel = React.forwardRef<
 		};
 	}, [id, isActive, handleClose]);
 
+	const { isMobile } = useSidebar();
+
 	return (
 		<AnimatePresence>
 			{isActive && (
@@ -731,12 +733,18 @@ const SidebarPanel = React.forwardRef<
 						}
 					}}
 					className={cn(
-						'sidebar-panel absolute top-0 left-0 bg-white shadow-md -z-10',
+						'sidebar-panel absolute top-0 bg-white shadow-md',
+						isMobile 
+							? 'left-0 w-[--sidebar-width] h-full z-40'
+							: 'left-0 -z-10',
 						className
 					)}
-					initial={{ x: -sidebarWidth }}
-					animate={{ x: sidebarWidth }}
-					exit={{ x: -sidebarWidth }}
+					style={isMobile ? {
+						'--sidebar-width': SIDEBAR_WIDTH_MOBILE,
+					} as React.CSSProperties : undefined}
+					initial={isMobile ? { x: 0 } : { x: -sidebarWidth }}
+					animate={isMobile ? { x: 0 } : { x: sidebarWidth }}
+					exit={isMobile ? { x: 0 } : { x: -sidebarWidth }}
 					transition={{ duration: 0.25 }}
 				>
 					<button

--- a/apps/src/components/ui/sidebar.tsx
+++ b/apps/src/components/ui/sidebar.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
-import { Sheet, SheetContent } from '@/components/ui/sheet';
+import { Sheet, SheetContent, SheetTitle, SheetDescription } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
 	Tooltip,
@@ -79,6 +79,8 @@ const Sidebar = React.forwardRef<
 						}
 						side={side}
 					>
+						<SheetTitle className="sr-only">Sidebar Navigation</SheetTitle>
+							<SheetDescription className="sr-only">Navigation sidebar for accessing different sections of the application</SheetDescription>
 						<div className="flex h-full w-full flex-col">
 							{children}
 						</div>


### PR DESCRIPTION
## Description

- Reported issue:
The sidebar shouldn't act like a drawer(on desktop).

This PR remove drawer functionality (SidebarTrigger component) from the app (only on desktop)

also I found an error in the console:
```console
DialogContent requires a DialogTitle for the component to be accessible for screen reader users.
If you want to hide the DialogTitle, you can wrap it with our VisuallyHidden component.
For more information, see https://radix-ui.com/primitives/docs/components/dialog
```

and also warning:
```console
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.
```

and resolved them too

## Related ticket
https://rm.ewdev.ca/issues/79162