### PR TITLE
Refs: 86864: prevent VariableDetails to be full-width on desktop

### DIFF
--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -45,6 +45,8 @@ const MapHeader: React.FC<MapInfoProps> = ({ data = null }): React.ReactElement 
 			// set the position of the panel to be below the header. ref here is the toggle buttons container element
 			setPanelProps({
 				direction: 'right',
+				// prevent full width on desktop
+				className: 'md:!left-auto',
 				position: {
 					top: ref.current?.getBoundingClientRect().top || 0,
 					left: 0,


### PR DESCRIPTION
## Description

Reported issue:
- The panel describing a variable no longer opens correctly
- The panel opens to full screen width due to a bug introduced during mobile fixes, and should return to how it was/how it is in the designs.

## Fix:

**Mobile: Full width**
![image](https://github.com/user-attachments/assets/fedab64c-a164-46f1-abd3-a52db954e775)

**Desktop: Stick to the right**
![image](https://github.com/user-attachments/assets/ae5fcf78-a5fa-475b-932d-229c0b6d66b7)


## Related ticket
https://rm.ewdev.ca/issues/86864