### PR TITLE
Refs: 85617: FFix: incorrect median year is shown on the region tooltip pop-up

### DIFF
--- a/apps/src/components/map-layers/raster-precalculated-climate-variable-values.tsx
+++ b/apps/src/components/map-layers/raster-precalculated-climate-variable-values.tsx
@@ -34,7 +34,13 @@ const RasterPrecalcultatedClimateVariableValues: React.FC<RasterPrecalcultatedCl
 	const unit = climateVariable?.getUnit();
 	const decimals = climateVariable?.getUnitDecimalPlaces() ?? 0;
 	const dateRange = useMemo(() => {
-		return climateVariable?.getDateRange() ?? ["2041", "2070"];
+		const origRange = climateVariable?.getDateRange() ?? ["2041", "2070"];
+		const range = [...origRange];
+		// Force YYY1 instead of YYY0
+		if (range[0] && parseInt(range[0]) % 10 === 0) {
+			range[0] = (parseInt(range[0]) + 1).toString();
+		}
+		return range;
 	}, [climateVariable]);
 	const section = useContext(SectionContext);
 


### PR DESCRIPTION
## Description

(Replace this paragraph with a description of changes introduced by your pull
request. If applicable, don't hesitate to include context for the changes,
description of incorrect behaviour fixed, reasons for a new feature, etc.)

## Related ticket

https://rm.ewdev.ca/issues/85617