### PR TITLE
refs #82020: add logic for downloading station map files

### DIFF
--- a/apps/src/components/download/step-result.tsx
+++ b/apps/src/components/download/step-result.tsx
@@ -6,9 +6,9 @@ import {
 	StepContainerDescription,
 } from '@/components/download/step-container';
 import { useClimateVariable } from "@/hooks/use-climate-variable";
-import { useAppSelector } from '@/app/hooks';
-import { DownloadType, StationDownloadUrlsProps, DownloadFile, FrequencyType, FileFormatType } from '@/types/climate-variable-interface';
+import { DownloadType, DownloadFile } from '@/types/climate-variable-interface';
 import { cn } from '@/lib/utils';
+import { useAppSelector } from '@/app/hooks';
 
 /**
  * Result step, the final one, allows the user to make download file or see a success message.
@@ -16,7 +16,7 @@ import { cn } from '@/lib/utils';
 const StepResult = React.forwardRef(() => {
 	const { __ } = useI18n();
 	const { climateVariable } = useClimateVariable();
-	const { requestResult } = useAppSelector((state) => state.download);
+	const { requestResult, downloadLinks } = useAppSelector((state) => state.download);
 
 	const [containerTitle, setContainerTitle] = useState<string | null>(null);
 	const [containerDescription, setContainerDescription] = useState<string | null>(null);
@@ -24,90 +24,19 @@ const StepResult = React.forwardRef(() => {
 	// For precalculated climate variables
 	const [files, setFiles] = useState<DownloadFile[]>([]);
 
-	// Success messages
-	const analyzedRequestSuccessMessage = __('It may take 30 to 90 minutes to complete, depending on available resources.');
-	const downloadSuccessMessage = __('Your file is ready to download. Click the button below to start the download.');
-	const multipleDownloadSuccessMessage = __('Your files are ready to download. Click the buttons below to start the download.');
-	// Error messages
-	const downloadErrorMessage = __('An error occurred while preparing your file. Please try again later.');
-
-	// Set title, description and file/analyzed request result
+	// Set title, description and file
 	useEffect(() => {
-		if (requestResult && requestResult?.status === 'accepted' && climateVariable?.getDownloadType() === DownloadType.ANALYZED) {
-			setContainerTitle(__('Your request has been sent.'));
-			setContainerDescription(analyzedRequestSuccessMessage);
-			return;
-		}
-
-		const frequency = climateVariable?.getFrequency();
-
-		if (climateVariable?.getDownloadType() === DownloadType.PRECALCULATED && frequency !== FrequencyType.DAILY) {
-			// Download precalculated climate variables
-			// and not daily frequency (daily frequency are analyzed)
-
-			setContainerTitle(__('Download your file'));
-			setContainerDescription(__('Your request is being sent...'));
-
-			if(climateVariable.getInteractiveMode() === 'region') {
-				// Precalcultated variables (no station)
-
-				// Generate the file to be downloaded.
-				climateVariable.getDownloadUrl()
-				.then((url) => {
-					const file: DownloadFile = {
-						url: url ?? '',
-						label: 'file.zip'
-					};
-					setFiles([file]);
-
-					setContainerDescription(downloadSuccessMessage);
-				})
-				.catch(() => {
-					setContainerDescription(downloadErrorMessage);
-				});
-			} else if(climateVariable.getInteractiveMode() === 'station') {
-				// For station variables
-
-				// TODO: set StationDownloadUrlsProps
-				// TODO: replace with correct data
-				const stationDownloadUrlsProps: StationDownloadUrlsProps = {} as StationDownloadUrlsProps;
-				if(climateVariable.getId() === 'msc_climate_normals') {
-					stationDownloadUrlsProps.stationIds = ['7113534', '8502800'];
-					stationDownloadUrlsProps.fileFormat = climateVariable.getFileFormat() ?? FileFormatType.CSV;
-				} else if(climateVariable.getId() === 'daily_ahccd_temperature_and_precipitation') {
-					stationDownloadUrlsProps.stationIds = ['7093GJ5', '7115800'];
-					stationDownloadUrlsProps.fileFormat = climateVariable.getFileFormat() ?? FileFormatType.CSV;
-				}
-				else if(climateVariable.getId() === 'future_building_design_value_summaries') {
-					stationDownloadUrlsProps.stationName = 'Happy Valley-Goose Bay, NL';
-				}
-				else if(climateVariable.getId() === 'short_duration_rainfall_idf_data') {
-					stationDownloadUrlsProps.stationId = '8501132';
-				}
-				else if(climateVariable.getId() === 'station_data') {
-					stationDownloadUrlsProps.stationIds = ['54058', '6093'];
-					stationDownloadUrlsProps.fileFormat = climateVariable.getFileFormat() ?? FileFormatType.CSV;
-					stationDownloadUrlsProps.dateRange = {start: '1840-03-01', end: '2025-05-06'};
-				}
-
-				climateVariable.getStationDownloadFiles(stationDownloadUrlsProps)
-				.then((downloadFiles) => {
-					if(downloadFiles.length > 1) {
-						setContainerDescription(multipleDownloadSuccessMessage);
-					} else if(downloadFiles.length > 0) {
-						setContainerDescription(downloadSuccessMessage);
-					} else {
-						setContainerDescription(downloadErrorMessage);
-					}
-
-					setFiles(downloadFiles);
-				})
-				.catch(() => {
-					setContainerDescription(downloadErrorMessage);
-				});
+		if (climateVariable?.getDownloadType() === DownloadType.ANALYZED && requestResult) {
+			if (requestResult?.status === 'accepted') {
+				setContainerTitle(__('Your request has been sent.'));
+				setContainerDescription(__('It may take 30 to 90 minutes to complete, depending on available resources.'));
 			}
+		} else if (climateVariable?.getDownloadType() === DownloadType.PRECALCULATED && downloadLinks) {
+			setContainerTitle(__('Your file is ready to download.'));
+			setContainerDescription('Click the button below to start the download.');
+			setFiles(downloadLinks);
 		}
-	}, [climateVariable, requestResult, __]);
+	}, [climateVariable, requestResult, downloadLinks, __]);
 
 	// Cleanup files when the component unmounts
 	useEffect(() => {
@@ -127,16 +56,14 @@ const StepResult = React.forwardRef(() => {
 			</StepContainerDescription>
 
 			<div className="step-result">
-				{files.length > 0 && (
+				{downloadLinks && downloadLinks.length > 0 && (
 					<div className="mt-4">
-						{files.map((file, index) => (
+						{downloadLinks.map((file, index) => (
 							<p key={index} className="mb-2">
 								<a
 									href={file.url}
 									download={file.label}
-									className={cn(
-										'text-lg font-semibold text-brand-blue underline ',
-									)}
+									className={cn('text-lg font-semibold text-brand-blue underline ')}
 									target="_blank"
 								>
 									{__('Download')} {file.label}
@@ -145,7 +72,6 @@ const StepResult = React.forwardRef(() => {
 						))}
 					</div>
 				)}
-
 				{climateVariable?.getId() === 'msc_climate_normals' && (
 					<p>
 						{__('Additional Climate Normals variables are available from the')} <a href="https://climate-change.canada.ca/climate-data/#/climate-normals" target="_blank" className='text-dark-purple'>{__('Canadian Centre for Climate Services')}</a> {__('and the')} <a href="https://climate.weather.gc.ca/climate_normals/index_e.html" target="_blank" className='text-dark-purple'>{__('Government of Canada Historical Climate Data')}</a> {__('websites.')}

--- a/apps/src/features/download/download-slice.ts
+++ b/apps/src/features/download/download-slice.ts
@@ -9,6 +9,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { DownloadState, TaxonomyData } from '@/types/types';
 import { CANADA_CENTER, DEFAULT_ZOOM } from '@/lib/constants';
 import { LatLngExpression } from 'leaflet';
+import { DownloadFile } from '@/types/climate-variable-interface';
 
 // Define the initial state this slice is going to use.
 export const initialState: DownloadState = {
@@ -23,6 +24,7 @@ export const initialState: DownloadState = {
 	variableListLoading: false,
 	captchaValue: '',
 	currentStep: 1,
+	downloadLinks: undefined,
 };
 
 // Create the slice
@@ -81,6 +83,12 @@ const downloadSlice = createSlice({
 			state.dataset = state.dataset; // Keep dataset
 			state.currentStep = 1;
 		},
+		setDownloadLinks(state, action: PayloadAction<DownloadFile[] | undefined>) {
+			state.downloadLinks = action.payload;
+		},
+		resetDownloadLinks(state) {
+			state.downloadLinks = undefined;
+		},
 	},
 });
 
@@ -102,6 +110,8 @@ export const {
 	setCaptchaValue,
 	setCurrentStep,
 	resetVariableSelection,
+	setDownloadLinks,
+	resetDownloadLinks,
 } = downloadSlice.actions;
 
 // Export reducer

--- a/apps/src/services/services.ts
+++ b/apps/src/services/services.ts
@@ -468,7 +468,7 @@ export const fetchChoroValues = async (options: ChoroValuesOptions) => {
  *
  * @returns A list of stations with their names, ids and coords.
  */
-export const fetchStationsList = async ({ type }: { type?: string }) => {
+export const fetchStationsList = async ({ threshold }: { threshold?: string }) => {
 	try {
 		let data: any;
 
@@ -486,20 +486,22 @@ export const fetchStationsList = async ({ type }: { type?: string }) => {
 			return response.json();
 		};
 
-		if (type && type === 'ahccd') {
+		if (threshold === 'ahccd') {
 			// TEMPORARY: Using local dummy JSON due to CORS issue
 			data = ahccdData;
 
 			// TO ENABLE WHEN CORS IS FIXED:
 			// data = await fetchJson('https://data.climatedata.ca/fileserver/ahccd/ahccd.json');
+		} else if (threshold === 'station-data') {
+			data = await fetchJson('https://api.weather.gc.ca/collections/climate-stations/items?f=json&limit=10000&properties=STATION_NAME,STN_ID,LATITUDE,LONGITUDE');
 		} else {
 			data = await fetchJson('https://api.weather.gc.ca/collections/climate-stations/items?f=json&limit=10000&properties=STATION_NAME,STN_ID&startindex=0&HAS_NORMALS_DATA=Y');
 		}
 
 		return (data.features || []).map((feature: any) => ({
-			id: feature.properties?.STN_ID ?? feature.properties?.ID,
+			id: feature.properties?.ID ?? (threshold === 'station-data') ? feature.properties?.STN_ID : feature?.id,
 			name: feature.properties?.STATION_NAME ?? feature.properties?.Name,
-			type: feature.properties.type,
+			type: feature.properties?.type,
 			coordinates: {
 				lat: feature.geometry.coordinates[1],
 				lng: feature.geometry.coordinates[0],

--- a/apps/src/types/climate-variable-interface.ts
+++ b/apps/src/types/climate-variable-interface.ts
@@ -161,7 +161,7 @@ export interface StationDownloadUrlsProps {
 	stationId?: string;
 	stationIds?: string[];
 	stationName?: string;
-	fileFormat?: string;
+	fileFormat?: FileFormatType | null;
 	dateRange?: {start: string, end: string}
 }
 

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -5,7 +5,7 @@ import { buttonVariants } from '@/lib/format';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { LucideIcon } from 'lucide-react';
 import L from 'leaflet';
-import { ClimateVariableConfigInterface } from '@/types/climate-variable-interface';
+import { ClimateVariableConfigInterface, DownloadFile } from '@/types/climate-variable-interface';
 
 /**
  * Represents valid locale values.
@@ -206,6 +206,7 @@ export interface DownloadState {
 	requestResult?: any;
 	requestError?: string | null;
 	captchaValue: string;
+	downloadLinks?: DownloadFile[];
 	currentStep: number;
 }
 
@@ -638,6 +639,7 @@ export interface VariableFilterCountProps {
 export interface Station {
 	id: string;
 	name: string;
+	type?: string;
 	coordinates: {
 		lat: number;
 		lng: number;


### PR DESCRIPTION
## Description

This PR will add logic for downloading files for station maps in the download app.

- Refactor the logic for building stationDownloadUrlsProps in the download flow to use data from climateVariable instead of hardcoded values.
- Add basic for all station based variable types (AHCCD, station-data, climate normals, etc.), some extra logic might need to be added in future tickets.
- Update the fetchStationsList service method to return a consistent station object structure depending on the variable it's used for.
- Limit station type filtering logic only for AHCCD variables, matching the legacy behavior (please confirm this is right).

Note: for the `station_data` variable, the stations list is 8621 items. This makes selecting/unselecting stations slower than for other variables. This same issue happens in v1, but it should be addressed -- likely in a future bug/feature ticket.