### PR TITLE
refs #82016: Added default date range property

### DIFF
--- a/apps/src/components/download/step-additional-details.tsx
+++ b/apps/src/components/download/step-additional-details.tsx
@@ -87,9 +87,7 @@ const StepAdditionalDetails = React.forwardRef<StepComponentRef>((_, ref) => {
 				payload.averagingType = null;
 			}
 
-			if (climateVariable.getDateRangeConfig()) {
-				payload.dateRange = null;
-			}
+			payload.dateRange = climateVariable.getDefaultDateRange();
 
 			if (climateVariable.getScenarios()?.length) {
 				payload.analyzeScenarios = [];
@@ -121,6 +119,7 @@ const StepAdditionalDetails = React.forwardRef<StepComponentRef>((_, ref) => {
 
 	// Get the date range config.
 	const dateRangeConfig = climateVariable?.getDateRangeConfig();
+
 	// Get the date range selected by the user.
 	const dateRange = climateVariable?.getDateRange() ?? [];
 

--- a/apps/src/components/download/step-summary.tsx
+++ b/apps/src/components/download/step-summary.tsx
@@ -11,7 +11,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 
 import appConfig from '@/config/app.config';
-import { FileFormatType } from "@/types/climate-variable-interface";
+import { DownloadType, FileFormatType } from "@/types/climate-variable-interface";
 
 const VariableOptionsSummary: React.FC = () => {
 	const { climateVariable } = useClimateVariable();
@@ -87,6 +87,7 @@ const StepSummary: React.FC = () => {
 			summaryData.push({
 				title: __('Additional details'),
 				content: (() => {
+					const isDownloadTypeAnalyzed = climateVariable?.getDownloadType() === DownloadType.ANALYZED;
 					const [startYear, endYear] = climateVariable?.getDateRange() ?? ['2041', '2070'];
 					const frequency = climateVariable?.getFrequency() ?? '';
 					const percentiles = climateVariable?.getPercentiles() ?? [];
@@ -94,8 +95,10 @@ const StepSummary: React.FC = () => {
 
 					const data = [];
 
-					if (startYear && endYear) {
-						data.push(`${startYear}-${endYear}`);
+					if (isDownloadTypeAnalyzed) {
+						if (startYear && endYear) {
+							data.push(`${startYear}-${endYear}`);
+						}
 					}
 
 					if (frequency && frequency !== '') {

--- a/apps/src/config/climate-variables.config.ts
+++ b/apps/src/config/climate-variables.config.ts
@@ -1222,9 +1222,9 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 			},
 		],
 		frequencyConfig: {
-			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
-			[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.DOWNLOAD,
-			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.DOWNLOAD,
+			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.MAP,
+			[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.NONE,
+			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.NONE,
 			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
 		},
 		averagingOptions: [
@@ -1387,9 +1387,9 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 		threshold: "hddheat_18",
 		unit: 'Degree Days',
 		frequencyConfig: {
-			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.ALWAYS,
+			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.MAP,
 			[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.DOWNLOAD,
-			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.DOWNLOAD,
+			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.NONE,
 			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
 		},
 		averagingOptions: [
@@ -1489,6 +1489,12 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 			AveragingType.ALL_YEARS,
 			AveragingType.THIRTY_YEARS,
 		],
+		frequencyConfig: {
+			[FrequencyType.ANNUAL]: FrequencyDisplayModeOption.MAP,
+			[FrequencyType.MONTHLY]: FrequencyDisplayModeOption.ALWAYS,
+			[FrequencyType.SEASONAL]: FrequencyDisplayModeOption.NONE,
+			[FrequencyType.ANNUAL_JUL_JUN]: FrequencyDisplayModeOption.DOWNLOAD,
+		},
 		unit: 'Days',
 		temporalThresholdConfig: {
 			thresholds: {

--- a/apps/src/config/climate-variables.config.ts
+++ b/apps/src/config/climate-variables.config.ts
@@ -778,7 +778,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 				}
 			}
 		],
-		dateRange: [
+		defaultDateRange: [
 			"1980",
 			"2010",
 		],
@@ -816,7 +816,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 				}
 			}
 		],
-		dateRange: [
+		defaultDateRange: [
 			"1980",
 			"2010",
 		],
@@ -895,6 +895,10 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 					placeholder: "0",
 				}
 			},
+		],
+		defaultDateRange: [
+			"1980",
+			"2010",
 		],
 	},
 	/** Days above Tmax */
@@ -1044,7 +1048,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 				}
 			},
 		],
-		dateRange: [
+		defaultDateRange: [
 			"1980",
 			"2010",
 		],
@@ -1177,7 +1181,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 				}
 			}
 		],
-		dateRange: [
+		defaultDateRange: [
 			"1980",
 			"2010",
 		],
@@ -1322,7 +1326,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 				}
 			},
 		],
-		dateRange: [
+		defaultDateRange: [
 			"1980",
 			"2010",
 		],
@@ -1430,7 +1434,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 				}
 			},
 		],
-		dateRange: [
+		defaultDateRange: [
 			"1980",
 			"2010",
 		],
@@ -1457,7 +1461,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 				}
 			},
 		],
-		dateRange: [
+		defaultDateRange: [
 			"1980",
 			"2010",
 		],
@@ -1541,7 +1545,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 				}
 			},
 		],
-		dateRange: [
+		defaultDateRange: [
 			"1980",
 			"2010",
 		],
@@ -1654,7 +1658,7 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 		threshold: "slr",
 		hasDelta: false,
 		enableColourOptions: false,
-		dateRange: [
+		defaultDateRange: [
 			"2040",
 			"2050",
 		],

--- a/apps/src/lib/climate-variable-base.tsx
+++ b/apps/src/lib/climate-variable-base.tsx
@@ -225,7 +225,11 @@ class ClimateVariableBase implements ClimateVariableInterface {
 	}
 
 	getDateRange(): string[] | null {
-		return this._config.dateRange ?? [
+		return this._config.dateRange ?? this.getDefaultDateRange();
+	}
+
+	getDefaultDateRange(): string[] | null {
+		return this._config.defaultDateRange ?? [
 			"2040",
 			"2070",
 		];
@@ -321,7 +325,7 @@ class ClimateVariableBase implements ClimateVariableInterface {
 			// If projection
 			if (this.getDatasetType() === 'projection') {
 				analysisUrl += 'ensemble_grid_point_';
-			} 
+			}
 
 			// Add climate variable finch
 			analysisUrl += this.getFinch();

--- a/apps/src/types/climate-variable-interface.ts
+++ b/apps/src/types/climate-variable-interface.ts
@@ -279,6 +279,9 @@ export interface ClimateVariableConfigInterface {
 	/** Stores the selected date range */
 	dateRange?: string[] | null;
 
+	/** Stores the default date range */
+	defaultDateRange?: string[] | null;
+
 	/** Contains available averaging options */
 	averagingOptions?: AveragingType[];
 
@@ -411,6 +414,8 @@ export interface ClimateVariableInterface {
 	getDateRangeConfig(): DateRangeConfig | null;
 
 	getDateRange(): string[] | null;
+
+	getDefaultDateRange(): string[] | null;
 
 	getAveragingOptions(): AveragingType[];
 


### PR DESCRIPTION
## Description

- Adds a new property called defaultDateRange, which allows the dateRange to be reset to a default value when moving between steps
- Only display date range in the download summary when the variable is an analyzed variable
