### PR TITLE
refs #87696: Update ID mapping to handle 'climate-normals' threshold

### DIFF
--- a/apps/src/services/services.ts
+++ b/apps/src/services/services.ts
@@ -499,7 +499,7 @@ export const fetchStationsList = async ({ threshold }: { threshold?: string }) =
 		}
 
 		return (data.features || []).map((feature: any) => ({
-			id: String(feature.properties?.ID ?? (threshold === 'station-data' ? feature.properties?.STN_ID : feature?.id)),
+			id: String(feature.properties?.ID ?? ((threshold === 'station-data' || threshold === 'climate-normals') ? feature.properties?.STN_ID : feature?.id)),
 			name: feature.properties?.STATION_NAME ?? feature.properties?.Name,
 			type: feature.properties?.type,
 			coordinates: {


### PR DESCRIPTION
## Description

- Fixes an issue in the climate normals variable map where clicking a station shows an empty chart.
