### PR TITLE
Refs: #87692: fix: could not open variable information panel for default variable

### DIFF
--- a/apps/src/hooks/use-url-sync.ts
+++ b/apps/src/hooks/use-url-sync.ts
@@ -361,10 +361,12 @@ export const useUrlSync = () => {
 						config.id === firstVariable.id);
 					
 					if (matchingConfig) {
-						// Set climate variable with dataset context
+						// Set climate variable with dataset context and API data
 						const variableWithDataset = {
 							...matchingConfig,
-							datasetType: firstDataset.dataset_type
+							datasetType: firstDataset.dataset_type,
+							postId: firstVariable.postId,
+							title: firstVariable.title
 						};
 
 						// Set the variable


### PR DESCRIPTION
## Description

fix: could not open variable information panel for default variable

## How to test:

Clean the url params so app reloads and the default var gets set:
https://dev-en.climatedata.ca/map-app/

then the VariableDetailsPanel will show

## Related ticket

https://rm.ewdev.ca/issues/87692