### PR TITLE
Refs: #87354: fix: add Canadian province border lines to sea level map

### DIFF
--- a/apps/src/components/marine-map-container.tsx
+++ b/apps/src/components/marine-map-container.tsx
@@ -1,6 +1,6 @@
-import { useContext, useEffect, useMemo, useState } from 'react';
-import { MapContainer, TileLayer, WMSTileLayer, useMap } from 'react-leaflet';
-import { MAP_CONFIG, LAYER_KEYS } from '@/config/map.config';
+import { useContext, useMemo, useState } from 'react';
+import { MapContainer, TileLayer, WMSTileLayer } from 'react-leaflet';
+import { MAP_CONFIG, LAYER_KEYS, WMS_PARAMS } from '@/config/map.config';
 
 import MapLegend from '@/components/map-layers/map-legend';
 import VariableLayer from '@/components/map-layers/variable-layer';
@@ -23,22 +23,6 @@ import { cn, getDefaultFrequency, getFrequencyCode } from '@/lib/utils';
 import SectionContext from '@/context/section-provider';
 import { FrequencyType } from '@/types/climate-variable-interface';
 import appConfig from '@/config/app.config';
-
-/**
- * Applies CSS filters to make green landmass appear white
- */
-function LandmassStyler(): null {
-	const map = useMap();
-
-	useEffect(() => {
-		const pane = map.getPane('marineBasemap');
-		if (pane) {
-			pane.style.filter = MAP_CONFIG.landmassFilter;
-		}
-	}, [map]);
-
-	return null;
-}
 
 /**
  * Renders a Leaflet map for marine variables with a specialized approach:
@@ -146,7 +130,6 @@ export default function MarineMapContainer({
 
 			{/* Use the unified custom panes with 'marine' mode */}
 			<CustomPanesLayer mode="marine" />
-			<LandmassStyler />
 
 			{/* Use the unified variable layer */}
 			<VariableLayer layerValue={layerValue} />
@@ -182,6 +165,7 @@ export default function MarineMapContainer({
 			<WMSTileLayer
 				url={`${GEOSERVER_BASE_URL}/geoserver/wms`}
 				layers={LAYER_KEYS.landmass}
+				params={WMS_PARAMS.landmass}
 				format="image/png"
 				transparent={true}
 				version="1.1.1"

--- a/apps/src/config/map.config.ts
+++ b/apps/src/config/map.config.ts
@@ -43,9 +43,6 @@ export const MAP_CONFIG = {
 		custom_shapefile: 600
 	},
 
-	// Landmass filter for marine data (transforms green to white)
-	landmassFilter: 'saturate(100%) invert(100%) sepia(100%) saturate(0%) hue-rotate(298deg) brightness(100%) contrast(98%)',
-
 	// Opacity settings for overlays
 	defaultOpacity: 1.0,
 
@@ -59,4 +56,41 @@ export const MAP_CONFIG = {
 // Layer keys for WMS services
 export const LAYER_KEYS = {
 	landmass: "CDC:landmass"
+};
+
+// SLD definitions to style WMS landmass layer for sea level
+// @see: https://docs.geoserver.org/main/en/user/styling/sld/cookbook/lines.html#example-lines-layer
+export const SLD_STYLES = {
+	landmass: `<?xml version="1.0" encoding="UTF-8"?>
+<sld:StyledLayerDescriptor version="1.0.0"
+	xmlns="http://www.opengis.net/sld"
+	xmlns:sld="http://www.opengis.net/sld"
+	xmlns:ogc="http://www.opengis.net/ogc"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<sld:NamedLayer>
+		<sld:Name>CDC:landmass</sld:Name>
+		<sld:UserStyle>
+			<sld:Title>Light Gray Landmass</sld:Title>
+			<sld:FeatureTypeStyle>
+				<sld:Rule>
+					<sld:PolygonSymbolizer>
+						<sld:Fill>
+							<sld:CssParameter name="fill">#FAFAF8</sld:CssParameter>
+						</sld:Fill>
+						<sld:Stroke>
+							<sld:CssParameter name="stroke">#EEE0DF</sld:CssParameter>
+							<sld:CssParameter name="stroke-width">0.75</sld:CssParameter>
+							<sld:CssParameter name="stroke-dasharray">2 2</sld:CssParameter>
+						</sld:Stroke>
+					</sld:PolygonSymbolizer>
+				</sld:Rule>
+			</sld:FeatureTypeStyle>
+		</sld:UserStyle>
+	</sld:NamedLayer>
+</sld:StyledLayerDescriptor>`
+};
+
+export const WMS_PARAMS = {
+	landmass: { 'SLD_BODY': SLD_STYLES.landmass } as any
 };


### PR DESCRIPTION
## Description

Fix: add Canadian province border lines to sea level map.

added custom xml params to the request url to Geoserver to style WMS layer.

🔗 See: https://docs.geoserver.org/main/en/user/styling/sld/cookbook/lines.html#example-lines-layer

## Related ticket

https://rm.ewdev.ca/issues/87354