### PR TITLE
Refs #86890: Added Logic to remove search from comparison Map.

### DIFF
--- a/apps/src/components/raster-map-container.tsx
+++ b/apps/src/components/raster-map-container.tsx
@@ -32,10 +32,12 @@ export default function RasterMapContainer({
 	scenario,
 	onMapReady,
 	onUnmount,
+	isComparisonMap
 }: {
 	scenario: string | null | undefined;
 	onMapReady: (map: L.Map) => void;
 	onUnmount?: () => void;
+	isComparisonMap?: boolean;
 }) {
 	const [isLocationModalOpen, setIsLocationModalOpen] = useState(false);
 	const [locationModalContent, setLocationModalContent] = useState<React.ReactNode>(null);
@@ -123,15 +125,17 @@ export default function RasterMapContainer({
 			{climateVariable?.getInteractiveMode() === 'region' && (
 				<MapLegend url={`${GEOSERVER_BASE_URL}/geoserver/wms?service=WMS&version=1.1.0&request=GetLegendGraphic&format=application/json&layer=${layerValue}`} />
 			)}
-			
+
 			{/* Use the unified CustomPanesLayer with 'standard' mode */}
 			<CustomPanesLayer mode="standard" />
-			
+
 			{/* Use the unified VariableLayer */}
 			<VariableLayer layerValue={layerValue} />
-			
+
 			<ZoomControl />
-			<SearchControl />
+
+			{/* Show search control if not a comparison map. */}
+			{ !isComparisonMap && <SearchControl /> }
 
 			<LocationModal
 				isOpen={isLocationModalOpen}

--- a/apps/src/components/raster-map.tsx
+++ b/apps/src/components/raster-map.tsx
@@ -63,6 +63,7 @@ export default function RasterMap(): React.ReactElement {
 					setMap(map);
 				}}
 				onUnmount={() => (mapRef.current = null)}
+				isComparisonMap={false}
 			/>
 			{showComparisonMap && (
 				<RasterMapContainer
@@ -71,7 +72,8 @@ export default function RasterMap(): React.ReactElement {
 						comparisonMapRef.current = map;
 						syncMaps(); // sync once the comparison map is ready
 					}}
-					onUnmount={unsyncMaps} // unsync and clear the reference to this map
+					onUnmount={unsyncMaps}// unsync and clear the reference to this map
+					isComparisonMap={true}
 				/>
 			)}
 		</div>


### PR DESCRIPTION
## Description
- Added isComparisonMap boolean props to the RasterMapContainer component.
- Add logic not to show Search on secondary map (isComparisonMap true)
- From the RasterMap component, I am passing isComparisonMap false from the first map and isComparisonMap true from the second map.
## Related ticket
https://rm.ewdev.ca/issues/86890
