### PR TITLE
Refs: #88179: fix: Filter behavior in the Variables panel

### DIFF
--- a/apps/src/components/ui/dropdown.tsx
+++ b/apps/src/components/ui/dropdown.tsx
@@ -62,14 +62,12 @@ const DropdownGeneric = <T extends string | undefined>(
 
 	const handleValueChanged = (value: string) => {
 		if (value === 'all') {
-			setSelected(placeholderTranslated as T);
+			setSelected(undefined);
 			setSearch('');
+			onChange?.('' as T);
 		} else {
 			setSelected(value as T);
-		}
-
-		if (onChange) {
-			onChange(value as T);
+			onChange?.(value as T);
 		}
 	};
 


### PR DESCRIPTION
## Description

Variables continue to be displayed even after a user has selected different values in succession in these filters

## Related ticket

https://rm.ewdev.ca/issues/88179