### PR TITLE
Refs: #88177: skips option selection step for station data

### DIFF
--- a/apps/src/context/download-provider.tsx
+++ b/apps/src/context/download-provider.tsx
@@ -93,7 +93,7 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({
 				return [...STEPS];
 			}
 			
-			if (climateVariable?.getClass() === 'StationClimateVariable') {
+			if (climateVariable?.getClass() === 'StationClimateVariable' || climateVariable?.getClass() === 'StationDataClimateVariable') {
 				// skip step 3 (variable options) if it's a station variable
 				const skipIndexes = [2];
 				// skip step 5 (additional details) if it's a station variable (but not station variable)

--- a/apps/src/lib/station-data-climate-variable.tsx
+++ b/apps/src/lib/station-data-climate-variable.tsx
@@ -9,6 +9,14 @@ import StationClimateVariable from "@/lib/station-climate-variable";
 
 class StationDataClimateVariable extends StationClimateVariable {
 
+	getVersions(): string[] {
+		return [];
+	}
+
+	getVersion(): string | null {
+		return null;
+	}
+
 	getFrequencyConfig(): FrequencyConfig | null {
 		return null;
 	}


### PR DESCRIPTION
## Description

After selecting the variable (Step 2), the user now arrives at the “Select a location or area” step and bypasses the version selection.

## Related ticket

https://rm.ewdev.ca/issues/88177