### PR TITLE
refs #87686: fix localization error when refreshing page

### DIFF
--- a/apps/src/App.tsx
+++ b/apps/src/App.tsx
@@ -4,7 +4,6 @@ import { SidebarProvider } from '@/context/sidebar-provider';
 import Header from '@/components/header';
 import { MapWrapper } from "@/components/map-wrapper";
 import { MapProvider } from '@/context/map-provider';
-import { LocaleProvider } from '@/context/locale-provider';
 import { AnimatedPanelProvider } from '@/context/animated-panel-provider';
 import { ClimateVariableProvider } from "@/context/climate-variable-provider";
 
@@ -18,22 +17,20 @@ function App() {
 	useLeaflet();
 
 	return (
-		<LocaleProvider>
-			<ClimateVariableProvider>
-				<MapProvider>
-					<AnimatedPanelProvider>
-						<SidebarProvider>
-							<AppSidebar />
-							<SidebarTrigger className="lg:hidden absolute top-4 right-4 [&_svg]:size-6" />
-							<main className="flex flex-col h-screen">
-								<Header />
-								<MapWrapper />
-							</main>
-						</SidebarProvider>
-					</AnimatedPanelProvider>
-				</MapProvider>
-			</ClimateVariableProvider>
-		</LocaleProvider>
+		<ClimateVariableProvider>
+			<MapProvider>
+				<AnimatedPanelProvider>
+					<SidebarProvider>
+						<AppSidebar />
+						<SidebarTrigger className="lg:hidden absolute top-4 right-4 [&_svg]:size-6" />
+						<main className="flex flex-col h-screen">
+							<Header />
+							<MapWrapper />
+						</main>
+					</SidebarProvider>
+				</AnimatedPanelProvider>
+			</MapProvider>
+		</ClimateVariableProvider>
 	);
 }
 

--- a/apps/src/components/climate-data-chart.tsx
+++ b/apps/src/components/climate-data-chart.tsx
@@ -55,7 +55,7 @@ const ClimateDataChart: React.FC<{ title: string; latlng: L.LatLng; featureId: n
 	featureId,
 	data,
 }) => {
-	const { locale } = useLocale();
+	const { locale, getLocalized } = useLocale();
 	const { climateVariable } = useClimateVariable();
 	const decimals = climateVariable?.getUnitDecimalPlaces() ?? 0;
 	const { dataset } = useAppSelector((state) => state.map);
@@ -75,7 +75,7 @@ const ClimateDataChart: React.FC<{ title: string; latlng: L.LatLng; featureId: n
 	const [enableChartNavigator, setEnableChartNavigator] = useState(true);
 
 	// Subtitle displayed info
-	const datasetLabel = dataset?.title.en ?? '';
+	const datasetLabel = getLocalized(dataset) ?? '';
 	const climateVariableTitle = climateVariable?.getTitle() || variableList?.[0]?.title || '';
 	const versionLabel = appConfig.versions.filter((version) => version.value === climateVariable?.getVersion())[0]?.label;
 

--- a/apps/src/components/map-header.tsx
+++ b/apps/src/components/map-header.tsx
@@ -115,23 +115,22 @@ MapHeader.displayName = 'MapHeader';
 const Breadcrumbs: React.FC<{ onClick: () => void }> = ({
 	onClick,
 }) => {
-	const { locale } = useLocale();
+	const { locale, getLocalized } = useLocale();
 	const dataset = useAppSelector((state) => state.map.dataset);
 	const variableList = useAppSelector((state) => state.map.variableList);
 	const { climateVariable } = useClimateVariable();
 
 	const datasetName = useMemo(() => {
 		if (!dataset) return '';
-		return locale === 'fr' && dataset.title.fr
-			? dataset.title.fr
-			: dataset.title.en;
+
+		return getLocalized(dataset);
 	}, [dataset, locale]);
 
 	const variableTitle = useMemo(() => {
 		if (climateVariable && climateVariable.toObject().postId) {
 			return climateVariable.getTitle() || '';
 		}
-		
+
 		// If no explicit climate variable selection, but we have variableList data,
 		// show the first variable as a fallback
 		if (variableList && variableList.length > 0) {

--- a/apps/src/components/map-layers/location-modal-content.tsx
+++ b/apps/src/components/map-layers/location-modal-content.tsx
@@ -4,6 +4,7 @@ import { ArrowRight } from 'lucide-react';
 import L from 'leaflet';
 import { useClimateVariable } from "@/hooks/use-climate-variable";
 import { useAppSelector } from '@/app/hooks';
+import { useLocale } from '@/hooks/use-locale';
 import appConfig from '@/config/app.config';
 
 interface LocationModalContentProps {
@@ -30,11 +31,12 @@ export const LocationModalContent: React.FC<LocationModalContentProps> = ({
 	onDetailsClick,
 }) => {
 	const { climateVariable } = useClimateVariable();
+	const { getLocalized } = useLocale();
 	const { dataset } = useAppSelector((state) => state.map);
 	const variableList = useAppSelector((state) => state.map.variableList);
 
 	// Displayed info
-	const datasetLabel = dataset?.title.en ?? '';
+	const datasetLabel = getLocalized(dataset);
 	const climateVariableTitle = climateVariable?.getTitle() || variableList?.[0]?.title || '';
 	const thresholds = climateVariable?.getThresholds() ?? [];
 	const threshold: string = climateVariable?.getThreshold() ?? '';

--- a/apps/src/components/map-layers/selectable-region-layer.tsx
+++ b/apps/src/components/map-layers/selectable-region-layer.tsx
@@ -28,7 +28,7 @@ const SelectableRegionLayer = forwardRef<{ clearSelection: () => void }, {}>((_,
 	const map = useMap();
 	const { climateVariable, setSelectedPoints, removeSelectedPoint } = useClimateVariable();
 	const dispatch = useAppDispatch();
-	const { getLocalizedLabel } = useLocale();
+	const { getLocalized } = useLocale();
 
 	// @ts-expect-error: suppress leaflet typescript error
 	const layerRef = useRef<L.VectorGrid | null>(null);
@@ -145,14 +145,14 @@ const SelectableRegionLayer = forwardRef<{ clearSelection: () => void }, {}>((_,
 				layerRef.current?.resetFeatureStyle(gid);
 			});
 
-			// add the feature to the selected points, including name from getLocalizedLabel
-			const name = getLocalizedLabel(e.layer?.properties || {});
+			// add the feature to the selected points, including name from getLocalized
+			const name = getLocalized(e.layer?.properties || {});
 			layerRef.current.setFeatureStyle(featureId, selectedStyles);
 			setSelectedPoints({
 				[String(featureId)]: { ...e.latlng, name },
 			});
 		},
-		[selectedStyles, selectedIds, setSelectedPoints, removeSelectedPoint, getLocalizedLabel]
+		[selectedStyles, selectedIds, setSelectedPoints, removeSelectedPoint, getLocalized]
 	);
 
 	// ensure refs always have the latest function versions

--- a/apps/src/hooks/use-locale.ts
+++ b/apps/src/hooks/use-locale.ts
@@ -12,11 +12,33 @@ export const useLocale = () => {
 	const { locale, setLocale } = context;
 
 	/**
-	 * Returns the localized label value from an object with label_en and label_fr fields.
-	 * Falls back to label_en or empty string if not present.
+	 * Returns the localized value from an object.
+	 * Tries multiple common keys (e.g., label, title), supporting:
+	 * - Flat keys like label_en, title_fr
+	 * - Nested keys like label.en, title.fr
+	 * - Objects shaped like { en: '...', fr: '...' }
+	 * Falls back to the English ('en') version, or an empty string if none found.
 	 */
-	const getLocalizedLabel = (obj: { label_en?: string; label_fr?: string }) => {
-		return obj[`label_${locale}` as 'label_en' | 'label_fr'] || obj.label_en || '';
+	const getLocalized = (obj: any): string => {
+		if (!obj) return '';
+
+		const keys = ['label', 'title'];
+
+		for (const key of keys) {
+			const value =
+				obj?.[`${key}_${locale}`] || // e.g. label_en
+				obj?.[key]?.[locale] || // e.g. label.en
+				obj?.[`${key}_en`] || // e.g. label_en
+				obj?.[key]?.en; // e.g. label.en
+
+			if (value) {
+				return value;
+			}
+		}
+
+		// fallback if obj is directly { en: '...', fr: '...' }
+		return obj?.[locale] || obj?.en || '';
 	};
-	return { locale, setLocale, getLocalizedLabel };
+
+	return { locale, setLocale, getLocalized };
 };

--- a/apps/src/main-map.tsx
+++ b/apps/src/main-map.tsx
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 import { createI18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
 
+import { LocaleProvider } from '@/context/locale-provider';
 import { store } from '@/app/store';
 
 import App from '@/App';
@@ -18,7 +19,9 @@ createRoot(document.getElementById('root')!).render(
 		<Provider store={store}>
 			<I18nProvider i18n={i18n}>
 				<SectionContext.Provider value={'map'} >
-					<App />
+					<LocaleProvider>
+						<App />
+					</LocaleProvider>
 				</SectionContext.Provider>
 			</I18nProvider>
 		</Provider>


### PR DESCRIPTION
## Description

This PR will resolve an issue where the application would sometimes display the incorrect language translation for climate variable titles. The root cause was a hardcoded "en" locale being used when normalizing API data in the useUrlSync hook, which caused only English titles to be loaded regardless of the user's selected language.

Additionally, this PR addresses a related issue where the var query parameter could be lost from the URL after a page refresh. While this was not a reported bug, it heavily contributed for the incorrect translation bug due to the variable not being set on page load.