### PR TITLE
refs #88644: Fix download for climate normals variable - change start…

### DIFF
--- a/apps/src/lib/station-climate-variable.tsx
+++ b/apps/src/lib/station-climate-variable.tsx
@@ -87,7 +87,7 @@ class StationClimateVariable extends RasterPrecalculatedClimateVariable {
 
 			const stations = props?.stationIds?.map(stationId => stationId).join('|');
 			const fileFormat = props?.fileFormat === FileFormatType.GeoJSON ? 'json' : props?.fileFormat;
-			const url = `https://api.weather.gc.ca/collections/climate-normals/items?CLIMATE_IDENTIFIER=${stations}&sortby=MONTH&f=${fileFormat}&limit=150000&startindex=0`;
+			const url = `https://api.weather.gc.ca/collections/climate-normals/items?CLIMATE_IDENTIFIER=${stations}&sortby=MONTH&f=${fileFormat}&limit=150000&offset=0`;
 
 			return [{
 				label: '',

--- a/apps/src/lib/station-data-climate-variable.tsx
+++ b/apps/src/lib/station-data-climate-variable.tsx
@@ -51,7 +51,7 @@ class StationDataClimateVariable extends StationClimateVariable {
 		const start = props?.dateRange.start + ' 00:00:00';
 		const end = props?.dateRange.end + ' 00:00:00';
 		const fileFormat = props?.fileFormat === FileFormatType.GeoJSON ? 'json' : props?.fileFormat;
-		const url = `https://api.weather.gc.ca/collections/climate-daily/items?datetime=${start}/${end}&STN_ID=${stations}&sortby=PROVINCE_CODE,STN_ID,LOCAL_DATE&f=${fileFormat}&limit=150000&startindex=0`;
+		const url = `https://api.weather.gc.ca/collections/climate-daily/items?datetime=${start}/${end}&STN_ID=${stations}&sortby=PROVINCE_CODE,STN_ID,LOCAL_DATE&f=${fileFormat}&limit=150000&offset=0`;
 
 		return [{
 			label: '',

--- a/apps/src/services/services.ts
+++ b/apps/src/services/services.ts
@@ -493,11 +493,11 @@ export const fetchStationsList = async ({ threshold }: { threshold?: string }) =
 		} else if (threshold === 'idf') {
 			data = await fetchJson('/assets/themes/fw-child/resources/app/idf_curves.json');
 		} else {
-			data = await fetchJson('https://api.weather.gc.ca/collections/climate-stations/items?f=json&limit=10000&properties=STATION_NAME,STN_ID&startindex=0&HAS_NORMALS_DATA=Y');
+			data = await fetchJson('https://api.weather.gc.ca/collections/climate-stations/items?f=json&limit=10000&properties=STATION_NAME,STN_ID&offset=0&HAS_NORMALS_DATA=Y');
 		}
 
 		return (data.features || []).map((feature: any) => ({
-			id: String(feature.properties?.ID ?? ((threshold === 'station-data' || threshold === 'climate-normals') ? feature.properties?.STN_ID : feature?.id)),
+			id: String(feature.properties?.ID ?? ((threshold === 'station-data') ? feature.properties?.STN_ID : feature?.id)),
 			name: feature.properties?.STATION_NAME ?? feature.properties?.Name ?? feature.properties?.Location,
 			type: feature.properties?.type,
 			coordinates: {


### PR DESCRIPTION
Fix download for climate normals variable

Change startindex to offset attribute in API call and use CLIMATE_IDENTIFER instead of STN_ID as stations ids.
