### PR TITLE
refs #88722: Legend issues - fix default colour type when we switch t…

### DIFF
--- a/apps/src/components/sidebar-menu-items/data-values-control.tsx
+++ b/apps/src/components/sidebar-menu-items/data-values-control.tsx
@@ -26,7 +26,8 @@ const DataValuesControl: React.FC = () => {
 		setDataValue(value);
 
 		// also, colour type should be set depending on the data value and the colour scheme
-		const defaultsToDiscreteColourType = value === 'delta' && climateVariable?.getColourScheme() === 'default';
+		const colourScheme = climateVariable?.getColourScheme() ?? 'default';
+		const defaultsToDiscreteColourType = value === 'delta' && colourScheme === 'default';
 		setColourType(defaultsToDiscreteColourType ? ColourType.DISCRETE : ColourType.CONTINUOUS);
 	}
 


### PR DESCRIPTION
## Description

Legend issues:
fix default colour type when we switch to delta.

Logic to set discrete colour type if delta and default colour scheme was already there.
In `data-values-control.tsx`, `climateVariable?.getColourScheme()` is null when we first switch delta or colour scheme so I had to test to see and if it's null I consider that it's default colour scheme.