### PR TITLE
refs #85428: reset compare to value when changing the version.

### DIFF
--- a/apps/src/components/sidebar-menu-items/versions-dropdown.tsx
+++ b/apps/src/components/sidebar-menu-items/versions-dropdown.tsx
@@ -10,7 +10,7 @@ import appConfig from "@/config/app.config"
  * Versions dropdown component.
  */
 const VersionsDropdown: React.FC = () => {
-	const { climateVariable, setVersion, setScenarioCompare } = useClimateVariable();
+	const { climateVariable, setVersion, setScenarioCompare, setScenarioCompareTo } = useClimateVariable();
 
 	const options = appConfig.versions.filter((version) =>
 		climateVariable?.getVersions()?.includes(version.value)
@@ -27,6 +27,7 @@ const VersionsDropdown: React.FC = () => {
 
 		// Also reset compare scenarios checkbox
 		setScenarioCompare(false);
+		setScenarioCompareTo(null);
 	};
 
 	return (


### PR DESCRIPTION
## Description

We were resetting the checkbox value, but not the selected scenario, which ended being filtered if we came back to this scenario.

## Related ticket

https://rm.ewdev.ca/issues/85428
