### PR TITLE
refs #88746: Fix incoherent values between location info and chart.

### DIFF
--- a/apps/src/components/marine-map-container.tsx
+++ b/apps/src/components/marine-map-container.tsx
@@ -111,6 +111,7 @@ export default function MarineMapContainer({
 				variable: climateVariable?.getThreshold() ?? '',
 				frequency: frequency,
 				dataset: climateVariable?.getVersion() ?? '',
+				unitDecimals: climateVariable?.getUnitDecimalPlaces() ?? 0,
 			});
 
 			togglePanel(

--- a/apps/src/components/raster-map-container.tsx
+++ b/apps/src/components/raster-map-container.tsx
@@ -106,6 +106,7 @@ export default function RasterMapContainer({
 				variable: climateVariable?.getThreshold() ?? '',
 				frequency: frequency,
 				dataset: climateVariable?.getVersion() ?? '',
+				unitDecimals: climateVariable?.getUnitDecimalPlaces() ?? 0,
 			});
 
 			togglePanel(

--- a/apps/src/services/services.ts
+++ b/apps/src/services/services.ts
@@ -386,7 +386,8 @@ export const generateChartData = async (options: ChartDataOptions) => {
 		featureId,
 		dataset,
 		variable,
-		frequency
+		frequency,
+		unitDecimals
 	} = options;
 // 
 	let fetchUrl = `${window.DATA_URL}`;
@@ -404,7 +405,7 @@ export const generateChartData = async (options: ChartDataOptions) => {
 		fetchUrl += `/generate-regional-charts/${interactiveRegion}/${featureId}`;
 	}
 
-	fetchUrl += `/${variable}/${frequency}?decimals=1&dataset_name=${dataset}`;
+	fetchUrl += `/${variable}/${frequency}?decimals=${unitDecimals}&dataset_name=${dataset}`;
 	const response = await fetch(fetchUrl);
 
 	if (!response.ok) {

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -533,7 +533,7 @@ export interface ChartDataOptions {
 	dataset: string;
 	frequency: string;
 	unit?: string;
-	unitDecimals?: number;
+	unitDecimals: number;
 }
 
 export interface DeltaValuesOptions {


### PR DESCRIPTION
## Description

Fix incoherent values between location info and chart.
It was due to different decimal parameters. Now we use the variable unitDecimals attribute each time we call this API.