### PR TITLE
88740 sea level cmip5 map legend issue

### DIFF
--- a/apps/src/components/map-layers/interactive-regions-layer.tsx
+++ b/apps/src/components/map-layers/interactive-regions-layer.tsx
@@ -26,15 +26,24 @@ interface InteractiveRegionsLayerProps {
 	onOut?: () => void;
 	onClick?: (e: { latlng: L.LatLng; layer: { properties: any } }) => void;
 	layerRef?: React.MutableRefObject<any>;
+	isComparisonMap: boolean;
 }
 
-const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({ scenario, onOver, onOut, onClick, layerRef }) => {
+const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({
+	scenario,
+	onOver,
+	onOut,
+	onClick,
+	layerRef,
+	isComparisonMap = false,
+}) => {
 	const [layerData, setLayerData] = useState<Record<number, number> | null>(null);
 	const map = useMap();
 	const section = useContext(SectionContext);
 
 	const {
 		opacity: { mapData },
+		transformedLegendEntry,
 	} = useAppSelector((state) => state.map);
 
 	const { climateVariable } = useClimateVariable();
@@ -62,6 +71,13 @@ const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({ scena
 				return '#fff';
 			}
 
+			// We override color if it's for the comparison map of sea level variable
+			// if(isComparisonMap && climateVariable?.getId() === "sea_level" && transformedLegendEntry.length > 0) {
+			// 	console.log('override');
+			// 	colorMap.colours = transformedLegendEntry.map((entry) => entry.color) ?? [];
+      // 	colorMap.quantities = transformedLegendEntry.map((entry) => Number(entry.quantity)) ?? [];
+			// }
+
 			// Extract value based on interactive region type
 			const value =
 				interactiveRegion === InteractiveRegionOption.GRIDDED_DATA
@@ -70,7 +86,7 @@ const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({ scena
 
 			return getColor(value);
 		},
-		[interactiveRegion, layerData, colorMap, getColor]
+		[interactiveRegion, layerData, colorMap, getColor, isComparisonMap, climateVariable, transformedLegendEntry]
 	);
 
 	const frequency = useMemo(() => {

--- a/apps/src/components/map-layers/interactive-regions-layer.tsx
+++ b/apps/src/components/map-layers/interactive-regions-layer.tsx
@@ -26,7 +26,6 @@ interface InteractiveRegionsLayerProps {
 	onOut?: () => void;
 	onClick?: (e: { latlng: L.LatLng; layer: { properties: any } }) => void;
 	layerRef?: React.MutableRefObject<any>;
-	isComparisonMap: boolean;
 }
 
 const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({
@@ -35,7 +34,6 @@ const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({
 	onOut,
 	onClick,
 	layerRef,
-	isComparisonMap = false,
 }) => {
 	const [layerData, setLayerData] = useState<Record<number, number> | null>(null);
 	const map = useMap();
@@ -43,7 +41,6 @@ const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({
 
 	const {
 		opacity: { mapData },
-		transformedLegendEntry,
 	} = useAppSelector((state) => state.map);
 
 	const { climateVariable } = useClimateVariable();
@@ -71,13 +68,6 @@ const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({
 				return '#fff';
 			}
 
-			// We override color if it's for the comparison map of sea level variable
-			// if(isComparisonMap && climateVariable?.getId() === "sea_level" && transformedLegendEntry.length > 0) {
-			// 	console.log('override');
-			// 	colorMap.colours = transformedLegendEntry.map((entry) => entry.color) ?? [];
-      // 	colorMap.quantities = transformedLegendEntry.map((entry) => Number(entry.quantity)) ?? [];
-			// }
-
 			// Extract value based on interactive region type
 			const value =
 				interactiveRegion === InteractiveRegionOption.GRIDDED_DATA
@@ -86,7 +76,7 @@ const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({
 
 			return getColor(value);
 		},
-		[interactiveRegion, layerData, colorMap, getColor, isComparisonMap, climateVariable, transformedLegendEntry]
+		[interactiveRegion, layerData, colorMap, getColor]
 	);
 
 	const frequency = useMemo(() => {

--- a/apps/src/components/map-layers/map-legend.tsx
+++ b/apps/src/components/map-layers/map-legend.tsx
@@ -6,7 +6,8 @@ import { useMap } from 'react-leaflet';
 import MapLegendControl from '@/components/map-legend-control';
 
 import { useAppDispatch } from '@/app/hooks';
-import { setLegendData } from '@/features/map/map-slice';
+import { useAppSelector } from "@/app/hooks";
+import { setLegendData, setTransformedLegendEntry } from '@/features/map/map-slice';
 import { transformLegendData } from '@/lib/format';
 import { getCommonPrefix } from '@/lib/utils';
 import { fetchLegendData } from '@/services/services';
@@ -16,7 +17,10 @@ import { useColorMap } from '@/hooks/use-color-map';
 import { ColourType } from '@/types/climate-variable-interface';
 import { useLocale } from '@/hooks/use-locale';
 
-const MapLegend: React.FC<{ url: string }> = ({ url }) => {
+const MapLegend: React.FC<{ url: string; isComparisonMap?: boolean }> = ({
+	url,
+	isComparisonMap = false,
+}) => {
 	const [isOpen, setIsOpen] = useState<boolean>(false);
 	const [rawLegendData, setRawLegendData] = useState<WMSLegendData | null>(null);
 	const [transformedLegendData, setTransformedLegendData] = useState<TransformedLegendEntry[] | null>(null);
@@ -25,6 +29,7 @@ const MapLegend: React.FC<{ url: string }> = ({ url }) => {
 	const dispatch = useAppDispatch();
 	const { climateVariable } = useClimateVariable();
 	const { colorMap } = useColorMap();
+	const transformedLegendEntry = useAppSelector((state) => state.map.transformedLegendEntry);
 
 	const { locale } = useLocale();
 	const isDelta = climateVariable?.getDataValue() === 'delta';
@@ -76,13 +81,21 @@ const MapLegend: React.FC<{ url: string }> = ({ url }) => {
 			return;
 		}
 
-		(async () => {
-			const transformedData: TransformedLegendEntry[] =
-				await transformLegendData(rawLegendData, colourScheme, temporalRange, isDelta, unit, locale, decimals, colorMap);
+		if(isComparisonMap && climateVariable?.getId() === "sea_level" && transformedLegendEntry.length > 0) {
+			setTransformedLegendData(transformedLegendEntry);
+		} else {
+			(async () => {
+				const transformedData: TransformedLegendEntry[] =
+					await transformLegendData(rawLegendData, colourScheme, temporalRange, isDelta, unit, locale, decimals, colorMap);
 
-			setTransformedLegendData(transformedData);
-		})();
-	}, [rawLegendData, colourScheme, colorMap, isCategorical, climateVariable]);
+				if(!isComparisonMap) {
+					dispatch(setTransformedLegendEntry(transformedData));
+				}
+
+				setTransformedLegendData(transformedData);
+			})();
+		}
+	}, [rawLegendData, colourScheme, colorMap, isCategorical, climateVariable, isComparisonMap, transformedLegendEntry]);
 
 	useEffect(() => {
 		if (!transformedLegendData) {

--- a/apps/src/components/map-layers/map-legend.tsx
+++ b/apps/src/components/map-layers/map-legend.tsx
@@ -95,7 +95,7 @@ const MapLegend: React.FC<{ url: string; isComparisonMap?: boolean }> = ({
 				setTransformedLegendData(transformedData);
 			})();
 		}
-	}, [rawLegendData, colourScheme, colorMap, isCategorical, climateVariable, isComparisonMap, transformedLegendEntry]);
+	}, [rawLegendData, colourScheme, colorMap, isCategorical, climateVariable, isComparisonMap]);
 
 	useEffect(() => {
 		if (!transformedLegendData) {
@@ -124,6 +124,7 @@ const MapLegend: React.FC<{ url: string; isComparisonMap?: boolean }> = ({
 					isCategorical={isCategorical}
 					isDelta={isDelta}
 					isDefaultColourScheme={colourScheme === 'default'}
+					isSeaLevel={climateVariable?.getId() === "sea_level"}
 					hasCustomScheme={hasCustomScheme}
 					colourType={colourType}
 					unit={unit}

--- a/apps/src/components/map-legend-control.tsx
+++ b/apps/src/components/map-legend-control.tsx
@@ -21,10 +21,11 @@ const MapLegendControl: React.FC<{
 	isCategorical?: boolean;
 	isDelta: boolean;
 	isDefaultColourScheme: boolean;
+	isSeaLevel: boolean;
 	hasCustomScheme?: boolean;
 	unit?: string;
 	colourType?: string;
-}> = ({ data, isOpen, toggleOpen, isCategorical, isDelta, isDefaultColourScheme, hasCustomScheme, unit, colourType }) => {
+}> = ({ data, isOpen, toggleOpen, isCategorical, isDelta, isDefaultColourScheme, isSeaLevel, hasCustomScheme, unit, colourType }) => {
 	const [svgWidth, setSvgWidth] = useState(0);
 	const [legendHeight, setLegendHeight] = useState<number | undefined>(undefined);
 	const svgRef = useRef<SVGSVGElement>(null);
@@ -51,12 +52,13 @@ const MapLegendControl: React.FC<{
 	const [minItemHeight, setMinItemHeight] = useState<number>(0);
 
 	useEffect(() => {
-		const currentMaxItemExtra = isCategorical || !isDefaultColourScheme || (isDefaultColourScheme && isDelta) ? 0 : 0.5;
-		const currentMinItemExtra = isCategorical  || (isDefaultColourScheme && isDelta)
+		const currentMaxItemExtra = isCategorical || !isDefaultColourScheme || (isDefaultColourScheme && isDelta) || isSeaLevel ? 0 : 0.5;
+		const currentMinItemExtra = isCategorical || (isDefaultColourScheme && isDelta) || isSeaLevel
 			? 0 : 
 			(isDefaultColourScheme && !isDelta) 
 				? 0.5
 				: 1;
+
 		const currentItemHeight = GRADIENT_HEIGHT / (totalLabels + currentMaxItemExtra + currentMinItemExtra);
 		const currentMaxItemHeight = currentItemHeight * (1 + currentMaxItemExtra);
 		const currentMinItemHeight = currentItemHeight * (1 + currentMinItemExtra);

--- a/apps/src/components/marine-map-container.tsx
+++ b/apps/src/components/marine-map-container.tsx
@@ -192,7 +192,11 @@ export default function MarineMapContainer({
 			<CustomPanesLayer mode="marine" />
 
 			{/* Use the unified variable layer */}
-			<VariableLayer layerValue={layerValue} scenario={scenario} />
+			<VariableLayer 
+				layerValue={layerValue}
+				scenario={scenario}
+				isComparisonMap={isComparisonMap}
+			/>
 
 			<ZoomControl />
 
@@ -213,7 +217,6 @@ export default function MarineMapContainer({
 					onOut={onOut}
 					onClick={onClick}
 					layerRef={layerRef}
-					isComparisonMap={isComparisonMap}
 				/>
 			)}
 

--- a/apps/src/components/marine-map-container.tsx
+++ b/apps/src/components/marine-map-container.tsx
@@ -182,7 +182,10 @@ export default function MarineMapContainer({
 				onUnmount={onUnmount}
 			/>
 			{climateVariable?.getInteractiveMode() === 'region' && (
-				<MapLegend url={`${GEOSERVER_BASE_URL}/geoserver/wms?service=WMS&version=1.1.0&request=GetLegendGraphic&format=application/json&layer=${layerValue}`} />
+				<MapLegend 
+					url={`${GEOSERVER_BASE_URL}/geoserver/wms?service=WMS&version=1.1.0&request=GetLegendGraphic&format=application/json&layer=${layerValue}`}
+					isComparisonMap={isComparisonMap}
+				/>
 			)}
 
 			{/* Use the unified custom panes with 'marine' mode */}
@@ -210,6 +213,7 @@ export default function MarineMapContainer({
 					onOut={onOut}
 					onClick={onClick}
 					layerRef={layerRef}
+					isComparisonMap={isComparisonMap}
 				/>
 			)}
 

--- a/apps/src/features/map/map-slice.ts
+++ b/apps/src/features/map/map-slice.ts
@@ -27,7 +27,7 @@
  */
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { MapState, MapLocation, WMSLegendData, TaxonomyData, PostData, MapCoordinates } from '@/types/types';
+import { MapState, MapLocation, WMSLegendData, TaxonomyData, PostData, MapCoordinates, TransformedLegendEntry } from '@/types/types';
 import {
 	SLIDER_DEFAULT_YEAR_VALUE,
 	SLIDER_MAX_YEAR,
@@ -59,6 +59,7 @@ const initialState: MapState = {
 		labels: 1,
 	},
 	legendData: {},
+	transformedLegendEntry: [],
 	variableList: [],
 	variableListLoading: false,
 	mapCoordinates: {
@@ -128,6 +129,9 @@ const mapSlice = createSlice({
 		setLegendData(state, action: PayloadAction<WMSLegendData>) {
 			state.legendData = action.payload;
 		},
+		setTransformedLegendEntry(state, action: PayloadAction<TransformedLegendEntry[]>) {
+			state.transformedLegendEntry = action.payload;
+		},
 		setOpacity(
 			state,
 			action: PayloadAction<{ key: keyof MapItemsOpacity; value: number }>
@@ -156,6 +160,7 @@ export const {
 	clearRecentLocations,
 	setMapColor,
 	setLegendData,
+	setTransformedLegendEntry,
 	setOpacity,
 	setMapCoordinates,
 } = mapSlice.actions;

--- a/apps/src/lib/colour-scheme.ts
+++ b/apps/src/lib/colour-scheme.ts
@@ -50,16 +50,18 @@ export function generateColourScheme(
 
 	const useDelta = climateVariable?.hasDelta() ?? false;
 
+	const quantities = calculateQuantities({
+		temporalScaleConfig,
+		useDelta: useDelta && climateVariable?.getDataValue() === "delta",
+		colours,
+		schemeType,
+		decimals
+	});
+
 	return {
 		colours,
 		type: schemeType,
-		quantities: calculateQuantities({
-			temporalScaleConfig,
-			useDelta: useDelta && climateVariable?.getDataValue() === "delta",
-			colours,
-			schemeType,
-			decimals
-		}),
+		quantities: quantities,
 		isDivergent: schemeType === 'divergent'
 	};
 }

--- a/apps/src/lib/sea-level-climate-variable.tsx
+++ b/apps/src/lib/sea-level-climate-variable.tsx
@@ -1,5 +1,5 @@
 import MarineClimateVariable from "@/lib/marine-climate-variable";
-import { DateRangeConfig, LocationModalContentParams } from "@/types/climate-variable-interface";
+import { DateRangeConfig, LocationModalContentParams, ColourType } from "@/types/climate-variable-interface";
 import MedianOnlyVariableValues from "@/components/map-layers/median-only-variable-values";
 
 class SeaLevelClimateVariable extends MarineClimateVariable {
@@ -27,6 +27,10 @@ class SeaLevelClimateVariable extends MarineClimateVariable {
 				scenario={scenario ?? ""}
 			/>
 		);
+	}
+
+	getColourType(): string | null {
+		return ColourType.DISCRETE;
 	}
 }
 

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -801,6 +801,7 @@ export interface WMSParams {
 export interface VariableLayerProps {
 	scenario: string | null | undefined;
 	layerValue: string;
+	isComparisonMap?: boolean;
 }
 
 export interface SelectedLocationInfo {

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -185,6 +185,7 @@ export interface MapState {
 	pane: string;
 	mapColor: string;
 	legendData: WMSLegendData;
+	transformedLegendEntry: TransformedLegendEntry[];
 	opacity: {
 		mapData: number;
 		labels: number;
@@ -251,6 +252,7 @@ export interface TransformedLegendEntry {
 	label: string | number;
 	color: string;
 	opacity: number;
+	quantity?: number;
 }
 
 /**


### PR DESCRIPTION
## Description

Sea level special case for comparison.
-> use the same legend on the second map for this variable.

- update the comparison map legend according to the other map legend
- override comparison map colors to match legend new colors
