### PR TITLE
refs #88736: Fix missing color in some map regions.

### DIFF
--- a/apps/src/components/map-layers/interactive-regions-layer.tsx
+++ b/apps/src/components/map-layers/interactive-regions-layer.tsx
@@ -126,7 +126,7 @@ const InteractiveRegionsLayer: React.FC<InteractiveRegionsLayerProps> = ({
 				weight: 1,
 				color: layerData ? '#fff' : '#999',
 				fillColor:
-					properties.id && layerData?.[properties.id]
+					properties.id && layerData?.[properties.id] !== undefined
 						? getFeatureColor(properties.id)
 						: 'transparent',
 				opacity: 0.5,


### PR DESCRIPTION
## Description

Fix missing color in some map regions.
-> When value was exactly 0, `properties.id && layerData?.[properties.id]` was false and we skipped color application, it was transparent.