### PR TITLE
Fix: cannot build Portal image if Task Runner is not built

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -79,6 +79,10 @@ function _check_for_required_build_assets {
 
 function start {
   _check_for_required_build_assets
+  # The Task Runner image must be built before building the Portal image, so
+  # we start it (i.e. build it, if required) first before starting the other
+  # services.
+  _docker_compose up -d task-runner
   _docker_compose up -d
 }
 


### PR DESCRIPTION
## Description

**Context:** the issue happens on a system where the Docker images (Task Runner and Portal images) have not already been built (ex: first time setting up the development environment).

**Issue:** when running `./dev start`, it will first build the Portal and Task Runner images, but it (sometimes) fails because it tries to build the Portal image _before_ the Task Runner image. The Portal image uses the Task Runner image, so it needs to be built _after_.

**Solution implemented:** the `./dev.sh start` command will now first start only the "Task Runner" service (which will build the Task Runner image, if required), then it will start the other services (and build the Portal image, if required).