### PR TITLE
dev.sh db to connect to mysql client CLI

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -29,6 +29,7 @@ function _show_help {
   echo "    nginx  <args...>        Execute a 'nginx' command in the 'Portal' container. All <args...> are passed to nginx."
   echo ""
   echo "  Database:"
+  echo "    db                      Enter 'mysql' client CLI to the default database to make queries."
   echo "    db-shell                Start a shell on the 'database' container."
   echo "    db-dump <database>      Dump to standard output the <database> database of the 'database' container."
   echo "    db-execute <database>   Execute the SQL script from standard input on the <database> database of the 'database' container."
@@ -116,6 +117,19 @@ function portal-shell {
 
 function wp-cli {
   _docker_compose exec -w /var/www/html portal wp "$@"
+}
+
+function db {
+  database="$1"
+  if [[ -z "$database" ]]; then
+    database="climatedata"
+  fi
+  echo "Connecting to MySQL '${database}' database. This should only work in development mode"
+  echo ""
+  echo "  Reminder: to exit, use CTRL+D key combination"
+  echo ""
+
+  _docker_compose exec -it db mysql -p'root' "$database"
 }
 
 function db-shell {


### PR DESCRIPTION
## Description

Instead of using an external MariaDB/MySQL client, we can use the container's internal `mysql` client directly.

The convention being that if `db-shell` gets into a bash CLI, `db-dump` creates a database backup, `db` alone gives access to the main purpose of that container.

Since it's a container for development, and WordPress instance expects only one database, we can assume that this won't do anything in other contexts.
