### PR TITLE
CLIM-1223: Accurate Info in LocationModal when we either use Search or the Locate button

### DIFF
--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -15,9 +15,21 @@ import 'leaflet-search';
 import mapPinIcon from '@/assets/map-pin.svg';
 
 import { cn, parseLatLon } from '@/lib/utils';
-import { fetchLocationByCoords } from '@/services/services';
-import { SearchControlLocationItem, SearchControlResponse } from '@/types/types';
-import { LOCATION_SEARCH_ENDPOINT, SEARCH_DEFAULT_ZOOM, SEARCH_PLACEHOLDER } from '@/lib/constants';
+import { useClimateVariable } from '@/hooks/use-climate-variable';
+import {
+	fetchLocationByCoords,
+	fetchRegionFeatureByCoords,
+} from '@/services/services';
+import type {
+	SearchControlLocationItem,
+	SearchControlResponse,
+} from '@/types/types';
+import { InteractiveRegionOption } from '@/types/climate-variable-interface';
+import {
+	LOCATION_SEARCH_ENDPOINT,
+	SEARCH_DEFAULT_ZOOM,
+	SEARCH_PLACEHOLDER,
+} from '@/lib/constants';
 
 /**
  * Lat/lng object returned by the Search component.
@@ -58,6 +70,7 @@ export default function SearchControl({
 	const [isGeolocationEnabled, setIsGeolocationEnabled] =
 		useState<boolean>(false);
 	const [isTracking, setIsTracking] = useState<boolean>(false);
+	const { climateVariable } = useClimateVariable();
 	const vectorLayer: any = layerRef?.current;
 
 	// we need a unique id for the search control container for cases where multiple maps
@@ -79,7 +92,7 @@ export default function SearchControl({
 	const map = useMap();
 
 	const handleLocationChange = useCallback(
-		(inputLatlng: SearchLatLng) => {
+		async (inputLatlng: SearchLatLng) => {
 			const latlng = convertSearchLatLng(inputLatlng);
 			// clear all existing markers from the map
 			map.eachLayer(layer => {
@@ -92,15 +105,31 @@ export default function SearchControl({
 			// The location will be saved via the click event.
 			// see handleClick() in use-map-interactions.tsx.
 			if (vectorLayer) {
+				const interactiveRegion = climateVariable?.getInteractiveRegion()
+					?? InteractiveRegionOption.GRIDDED_DATA;
+
+				// When a user clicks the map, VectorGrid provides feature
+				// properties from tile data automatically. Search and locate-me
+				// skip that interaction, so we resolve the properties via WFS.
+				const properties = await fetchRegionFeatureByCoords(
+					interactiveRegion,
+					latlng,
+				);
+
 				vectorLayer.fire('click', {
 					latlng: {
 						lat: latlng.lat,
 						lng: latlng.lng,
-					}
-				})
+					},
+					...(properties ? { layer: { properties } } : {}),
+				});
 			}
 		},
-		[map, vectorLayer]
+		[
+			climateVariable,
+			map,
+			vectorLayer,
+		]
 	);
 
 	const toggleGeoLocation = () => {

--- a/apps/src/services/services.ts
+++ b/apps/src/services/services.ts
@@ -453,6 +453,65 @@ export const fetchPostsData = async (
 };
 
 /**
+ * Maps {@link InteractiveRegionOption} values to GeoServer WFS layer names.
+ */
+const REGION_TO_WFS_LAYER: Partial<Record<InteractiveRegionOption, string>> = {
+	[InteractiveRegionOption.CENSUS]: 'CDC:census',
+	[InteractiveRegionOption.HEALTH]: 'CDC:health',
+	[InteractiveRegionOption.WATERSHED]: 'CDC:watershed',
+};
+
+/**
+ * Resolves the interactive region feature (id, gid, labels) that contains the
+ * given coordinates, by querying GeoServer WFS.
+ *
+ * This is only needed for the search and locate-me code paths, where no map
+ * tile interaction occurred. When the user clicks directly on the map,
+ * VectorGrid already provides these properties from the tile data — no
+ * network call is needed.
+ *
+ * Returns `null` when the region type is {@link InteractiveRegionOption.GRIDDED_DATA}
+ * (no feature ID needed), when no matching feature is found, or when the
+ * request is aborted.
+ *
+ * @param regionType - The active interactive region.
+ * @param latlng - Coordinates to resolve.
+ * @param fetchOptions - Any other options to pass to fetch (ex: `signal`).
+ */
+export const fetchRegionFeatureByCoords = async (
+	regionType: InteractiveRegionOption,
+	latlng: Pick<L.LatLng, 'lat' | 'lng'>,
+	fetchOptions?: FetchOptions,
+): Promise<Record<string, unknown> | null> => {
+	const layerName = REGION_TO_WFS_LAYER[regionType];
+	if (!layerName) {
+		return null;
+	}
+
+	type WfsResponse = {
+		features?: { properties?: Record<string, unknown> }[];
+	};
+
+	const data = await fetchJSON<WfsResponse>(
+		`${GEOSERVER_BASE_URL}/geoserver/CDC/ows`,
+		{
+			CQL_FILTER: `CONTAINS(the_geom,POINT(${latlng.lng} ${latlng.lat}))`,
+			maxFeatures: '1',
+			outputFormat: 'application/json',
+			propertyName: 'id,label_en,label_fr',
+			request: 'GetFeature',
+			service: 'WFS',
+			typeName: layerName,
+			version: '1.0.0',
+		},
+		fetchOptions,
+	);
+
+	const properties = data?.features?.[0]?.properties;
+	return properties ?? null;
+};
+
+/**
  * Fetches location data from the API
  *
  * @param latlng Latitude and Longitude of the location
@@ -480,7 +539,7 @@ export const fetchLocationByCoords = async (
  * @param fetchOptions Any other options to pass to fetch (ex: `signal`)
  */
 export const generateChartData = async (options: ChartDataOptions, fetchOptions?: FetchOptions) => {
-	const { 
+	const {
 		interactiveRegion,
 		latlng,
 		featureId,
@@ -489,7 +548,7 @@ export const generateChartData = async (options: ChartDataOptions, fetchOptions?
 		frequency,
 		unitDecimals
 	} = options;
-// 
+//
 	let fetchUrl = '';
 
 	if(interactiveRegion == InteractiveRegionOption.GRIDDED_DATA) {


### PR DESCRIPTION
## Problem

When using the Map with interactive regions (watershed, health, census), searching for a location or using "locate me" always queries the API with `featureId=0`:

```
/get-delta-30y-regional-values/watershed/0/tx_max/ann
```

This causes every search result to show the same incorrect data, regardless of location.

## Root Cause

When a user clicks directly on the map, VectorGrid provides feature properties (including the region `id`) from the tile data automatically. The search and locate-me paths skip that tile interaction — they fire a synthetic click event with coordinates but **no layer properties**. `getFeatureId()` receives `undefined`, returns `null`, and the downstream code falls back to `0`.

## Fix

Added `fetchRegionFeatureByCoords()` in `services.ts` — a GeoServer WFS query that resolves which interactive region contains the searched coordinates. `handleLocationChange()` in `search-control.tsx` now calls this before firing the synthetic click, passing the resolved properties into the event so `handleClick()` receives the same data shape as a real map click.

- One fix covers both search and locate-me (both converge on `handleLocationChange`)
- No changes to `handleClick()` or anything downstream
- For `GRIDDED_DATA` mode, no WFS call is made (not needed)

### Files changed

| File | Change |
|------|--------|
| `services.ts` | Added `fetchRegionFeatureByCoords()` — WFS query to `CDC/ows` endpoint |
| `search-control.tsx` | `handleLocationChange()` resolves region properties before firing click |

## Testing

For each interactive region type (watershed, census, health):

1. Select a variable (e.g., Hottest Day) and the region type
2. **Click** a region shape — note the popup values and the API URL in DevTools
3. **Search** for a location within that same region — verify the popup shows the same values and the API URL uses the correct `featureId` (not `/0/`)
4. **Locate me** — verify same behavior
5. **Switch to gridded data** — verify no WFS call is made and existing behavior is unchanged