### PR TITLE
CLIM-1223: TechDebt — dispatch real DOM PointerEvent on VectorGrid (pay principal on FI1)

### DIFF
--- a/apps/src/components/map-container.tsx
+++ b/apps/src/components/map-container.tsx
@@ -245,7 +245,7 @@ export default function MapContainer({
 			<ZoomControl />
 
 			{/* Show search control if not a comparison map. */}
-			{ !isComparisonMap && <SearchControl layerRef={layerRef} /> }
+			{ !isComparisonMap && <SearchControl /> }
 
 			<LocationModal
 				isOpen={canShowModal}

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -58,15 +58,12 @@ function convertSearchLatLng(inputLatLng: SearchLatLng): L.LatLng {
  */
 export default function SearchControl({
 	className,
-	layerRef,
 }: {
 	className?: string;
-	layerRef?: React.MutableRefObject<any>;
 }): ReactElement | null {
 	const [isGeolocationEnabled, setIsGeolocationEnabled] =
 		useState<boolean>(false);
 	const [isTracking, setIsTracking] = useState<boolean>(false);
-	void layerRef; // intentionally ignore to suppress typescript error
 
 	// we need a unique id for the search control container for cases where multiple maps
 	// are rendered on the same page -- ie. comparing emission scenarios

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -15,21 +15,9 @@ import 'leaflet-search';
 import mapPinIcon from '@/assets/map-pin.svg';
 
 import { cn, parseLatLon } from '@/lib/utils';
-import { useClimateVariable } from '@/hooks/use-climate-variable';
-import {
-	fetchLocationByCoords,
-	fetchRegionFeatureByCoords,
-} from '@/services/services';
-import type {
-	SearchControlLocationItem,
-	SearchControlResponse,
-} from '@/types/types';
-import { InteractiveRegionOption } from '@/types/climate-variable-interface';
-import {
-	LOCATION_SEARCH_ENDPOINT,
-	SEARCH_DEFAULT_ZOOM,
-	SEARCH_PLACEHOLDER,
-} from '@/lib/constants';
+import { fetchLocationByCoords } from '@/services/services';
+import { SearchControlLocationItem, SearchControlResponse } from '@/types/types';
+import { LOCATION_SEARCH_ENDPOINT, SEARCH_DEFAULT_ZOOM, SEARCH_PLACEHOLDER } from '@/lib/constants';
 
 /**
  * Lat/lng object returned by the Search component.
@@ -70,7 +58,6 @@ export default function SearchControl({
 	const [isGeolocationEnabled, setIsGeolocationEnabled] =
 		useState<boolean>(false);
 	const [isTracking, setIsTracking] = useState<boolean>(false);
-	const { climateVariable } = useClimateVariable();
 	const vectorLayer: any = layerRef?.current;
 
 	// we need a unique id for the search control container for cases where multiple maps
@@ -92,7 +79,7 @@ export default function SearchControl({
 	const map = useMap();
 
 	const handleLocationChange = useCallback(
-		async (inputLatlng: SearchLatLng) => {
+		(inputLatlng: SearchLatLng) => {
 			const latlng = convertSearchLatLng(inputLatlng);
 			// clear all existing markers from the map
 			map.eachLayer(layer => {
@@ -105,31 +92,15 @@ export default function SearchControl({
 			// The location will be saved via the click event.
 			// see handleClick() in use-map-interactions.tsx.
 			if (vectorLayer) {
-				const interactiveRegion = climateVariable?.getInteractiveRegion()
-					?? InteractiveRegionOption.GRIDDED_DATA;
-
-				// When a user clicks the map, VectorGrid provides feature
-				// properties from tile data automatically. Search and locate-me
-				// skip that interaction, so we resolve the properties via WFS.
-				const properties = await fetchRegionFeatureByCoords(
-					interactiveRegion,
-					latlng,
-				);
-
 				vectorLayer.fire('click', {
 					latlng: {
 						lat: latlng.lat,
 						lng: latlng.lng,
-					},
-					...(properties ? { layer: { properties } } : {}),
-				});
+					}
+				})
 			}
 		},
-		[
-			climateVariable,
-			map,
-			vectorLayer,
-		]
+		[map, vectorLayer]
 	);
 
 	const toggleGeoLocation = () => {

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -3,7 +3,7 @@
  * This component allows users to search for locations using the OpenStreetMap Nominatim API and navigate the map to the selected location.
  */
 
-import React, { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
+import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
 import { __ } from '@/context/locale-provider';
 import { Locate, LocateFixed } from 'lucide-react';
 import { useMap } from 'react-leaflet';
@@ -47,20 +47,25 @@ function convertSearchLatLng(inputLatLng: SearchLatLng): L.LatLng {
 }
 
 /**
+ * Props for the SearchControl component.
+ */
+export interface SearchControlProps {
+	className?: string;
+}
+
+/**
  * SearchControl Component
  * ---------------------------
  * A React component that adds a search control to a Leaflet map using the `leaflet-search` plugin.
  *
- * @returns {ReactElement | null} The rendered component (or null if not used within a map context).
+ * @returns {ReactElement} The rendered component.
  *
  * @example
  * <SearchControl />
  */
-export default function SearchControl({
+const SearchControl = ({
 	className,
-}: {
-	className?: string;
-}): ReactElement | null {
+}: SearchControlProps): ReactElement => {
 	const [isGeolocationEnabled, setIsGeolocationEnabled] =
 		useState<boolean>(false);
 	const [isTracking, setIsTracking] = useState<boolean>(false);
@@ -321,4 +326,6 @@ export default function SearchControl({
 			</div>
 		</div>
 	);
-}
+};
+
+export default SearchControl;

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -17,8 +17,15 @@ import mapPinIcon from '@/assets/map-pin.svg';
 import { cn, parseLatLon } from '@/lib/utils';
 import { dispatchMapClick } from '@/lib/dispatch-map-click';
 import { fetchLocationByCoords } from '@/services/services';
-import { SearchControlLocationItem, SearchControlResponse } from '@/types/types';
-import { LOCATION_SEARCH_ENDPOINT, SEARCH_DEFAULT_ZOOM, SEARCH_PLACEHOLDER } from '@/lib/constants';
+import {
+	type SearchControlLocationItem,
+	type SearchControlResponse,
+} from '@/types/types';
+import {
+	LOCATION_SEARCH_ENDPOINT,
+	SEARCH_DEFAULT_ZOOM,
+	SEARCH_PLACEHOLDER,
+} from '@/lib/constants';
 
 /**
  * Lat/lng object returned by the Search component.
@@ -92,7 +99,6 @@ export default function SearchControl({
 			await dispatchMapClick(map, latlng);
 		},
 		[
-			//
 			map,
 		],
 	);
@@ -235,8 +241,6 @@ export default function SearchControl({
 					iconAnchor: [12, 41], // Anchor of the icon
 					popupAnchor: [0, -41], // Popup position relative to the icon
 				}),
-			}).on('click', async (e: L.LayerEvent) => {
-				console.log(e);
 			}),
 			moveToLocation: (latlng: SearchLatLng) => {
 				handleLocationChange(latlng);

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -15,6 +15,7 @@ import 'leaflet-search';
 import mapPinIcon from '@/assets/map-pin.svg';
 
 import { cn, parseLatLon } from '@/lib/utils';
+import { dispatchMapClick } from '@/lib/dispatch-map-click';
 import { fetchLocationByCoords } from '@/services/services';
 import { SearchControlLocationItem, SearchControlResponse } from '@/types/types';
 import { LOCATION_SEARCH_ENDPOINT, SEARCH_DEFAULT_ZOOM, SEARCH_PLACEHOLDER } from '@/lib/constants';
@@ -79,7 +80,7 @@ export default function SearchControl({
 	const map = useMap();
 
 	const handleLocationChange = useCallback(
-		(inputLatlng: SearchLatLng) => {
+		async (inputLatlng: SearchLatLng) => {
 			const latlng = convertSearchLatLng(inputLatlng);
 			// clear all existing markers from the map
 			map.eachLayer(layer => {
@@ -88,6 +89,7 @@ export default function SearchControl({
 				}
 			});
 			map.setView(latlng, SEARCH_DEFAULT_ZOOM);
+			await dispatchMapClick(map, latlng);
 		},
 		[
 			//

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -3,7 +3,13 @@
  * This component allows users to search for locations using the OpenStreetMap Nominatim API and navigate the map to the selected location.
  */
 
-import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+	ReactElement,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from 'react';
 import { __ } from '@/context/locale-provider';
 import { Locate, LocateFixed } from 'lucide-react';
 import { useMap } from 'react-leaflet';

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -58,7 +58,7 @@ export default function SearchControl({
 	const [isGeolocationEnabled, setIsGeolocationEnabled] =
 		useState<boolean>(false);
 	const [isTracking, setIsTracking] = useState<boolean>(false);
-	const vectorLayer: any = layerRef?.current;
+	void layerRef; // intentionally ignore to suppress typescript error
 
 	// we need a unique id for the search control container for cases where multiple maps
 	// are rendered on the same page -- ie. comparing emission scenarios
@@ -88,19 +88,11 @@ export default function SearchControl({
 				}
 			});
 			map.setView(latlng, SEARCH_DEFAULT_ZOOM);
-
-			// The location will be saved via the click event.
-			// see handleClick() in use-map-interactions.tsx.
-			if (vectorLayer) {
-				vectorLayer.fire('click', {
-					latlng: {
-						lat: latlng.lat,
-						lng: latlng.lng,
-					}
-				})
-			}
 		},
-		[map, vectorLayer]
+		[
+			//
+			map,
+		],
 	);
 
 	const toggleGeoLocation = () => {

--- a/apps/src/components/sidebar-footer-links/recent-locations.tsx
+++ b/apps/src/components/sidebar-footer-links/recent-locations.tsx
@@ -18,7 +18,6 @@ import { SEARCH_DEFAULT_ZOOM } from '@/lib/constants';
 import { useMap } from '@/hooks/use-map';
 import { useSidebar } from '@/hooks/use-sidebar';
 import { cn } from '@/lib/utils';
-import L from 'leaflet';
 
 // link and panel slug
 const slug = 'recent-locations';
@@ -62,24 +61,6 @@ const RecentLocationsPanel: React.FC = () => {
 
 	const moveToLocation = (location: MapLocation) => {
 		map.setView(location, SEARCH_DEFAULT_ZOOM);
-		let vectorLayer: any;
-
-		// Find our vector layer.
-		map.eachLayer(layer => {
-			// @ts-expect-error: suppress leaflet typescript error
-			if (layer instanceof L.VectorGrid) {
-				vectorLayer = layer;
-			}
-		});
-
-		if (vectorLayer) {
-			vectorLayer.fire('click', {
-				latlng: {
-					lat: location.lat,
-					lng: location.lng
-				}
-			})
-		}
 	};
 
 	return (

--- a/apps/src/components/sidebar-footer-links/recent-locations.tsx
+++ b/apps/src/components/sidebar-footer-links/recent-locations.tsx
@@ -15,6 +15,7 @@ import { SidebarPanel } from '@/components/ui/sidebar';
 import { useAppSelector } from '@/app/hooks';
 import { MapLocation } from '@/types/types';
 import { SEARCH_DEFAULT_ZOOM } from '@/lib/constants';
+import { dispatchMapClick } from '@/lib/dispatch-map-click';
 import { useMap } from '@/hooks/use-map';
 import { useSidebar } from '@/hooks/use-sidebar';
 import { cn } from '@/lib/utils';
@@ -59,8 +60,9 @@ const RecentLocationsPanel: React.FC = () => {
 		return null;
 	}
 
-	const moveToLocation = (location: MapLocation) => {
+	const moveToLocation = async (location: MapLocation) => {
 		map.setView(location, SEARCH_DEFAULT_ZOOM);
+		await dispatchMapClick(map, location);
 	};
 
 	return (

--- a/apps/src/lib/dispatch-map-click.ts
+++ b/apps/src/lib/dispatch-map-click.ts
@@ -9,7 +9,7 @@ import L from 'leaflet';
  * tiles are queried via `gridPane.querySelectorAll('canvas')` and filtered
  * by bounding rect instead.
  *
- * `Promise.race` with a 500 ms timeout guards the case where `setView`
+ * `Promise.race` with a 1,000 ms timeout guards the case where `setView`
  * fires `moveend` synchronously (short pan, no animation) before the
  * listener is attached.
  */
@@ -20,7 +20,7 @@ export const dispatchMapClick = async (
 	void latlng;
 	await Promise.race([
 		new Promise<void>((resolve) => map.once('moveend', () => resolve())),
-		new Promise<void>((resolve) => setTimeout(resolve, 500)),
+		new Promise<void>((resolve) => setTimeout(resolve, 1_000)),
 	]);
 	await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 	const container = map.getContainer();

--- a/apps/src/lib/dispatch-map-click.ts
+++ b/apps/src/lib/dispatch-map-click.ts
@@ -1,0 +1,55 @@
+import L from 'leaflet';
+
+/**
+ * Dispatches a real DOM PointerEvent on the VectorGrid canvas tile at the
+ * map container center after the view settles.
+ *
+ * `pointer-events: none` on Leaflet's pane wrapper divs causes
+ * `document.elementFromPoint` to return the outermost container — canvas
+ * tiles are queried via `gridPane.querySelectorAll('canvas')` and filtered
+ * by bounding rect instead.
+ *
+ * `Promise.race` with a 500 ms timeout guards the case where `setView`
+ * fires `moveend` synchronously (short pan, no animation) before the
+ * listener is attached.
+ */
+export const dispatchMapClick = async (
+	map: L.Map,
+	latlng: { lat: number; lng: number },
+): Promise<void> => {
+	void latlng;
+	await Promise.race([
+		new Promise<void>((resolve) => map.once('moveend', () => resolve())),
+		new Promise<void>((resolve) => setTimeout(resolve, 500)),
+	]);
+	await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+	const container = map.getContainer();
+	const rect = container.getBoundingClientRect();
+	const clientX = rect.left + rect.width / 2;
+	const clientY = rect.top + rect.height / 2;
+	const gridPane = map.getPane('grid') ?? null;
+	if (!gridPane) {
+		return;
+	}
+	const canvases = Array.from(gridPane.querySelectorAll('canvas'));
+	const target = canvases.find((canvas) => {
+		const r = canvas.getBoundingClientRect();
+		return (
+			clientX >= r.left
+			&& clientX <= r.right
+			&& clientY >= r.top
+			&& clientY <= r.bottom
+		);
+	}) ?? null;
+	if (target) {
+		target.dispatchEvent(new PointerEvent('click', {
+			bubbles: true,
+			cancelable: true,
+			clientX,
+			clientY,
+			pointerId: 1,
+			pointerType: 'mouse',
+			view: window,
+		}));
+	}
+};

--- a/apps/src/services/services.ts
+++ b/apps/src/services/services.ts
@@ -453,65 +453,6 @@ export const fetchPostsData = async (
 };
 
 /**
- * Maps {@link InteractiveRegionOption} values to GeoServer WFS layer names.
- */
-const REGION_TO_WFS_LAYER: Partial<Record<InteractiveRegionOption, string>> = {
-	[InteractiveRegionOption.CENSUS]: 'CDC:census',
-	[InteractiveRegionOption.HEALTH]: 'CDC:health',
-	[InteractiveRegionOption.WATERSHED]: 'CDC:watershed',
-};
-
-/**
- * Resolves the interactive region feature (id, gid, labels) that contains the
- * given coordinates, by querying GeoServer WFS.
- *
- * This is only needed for the search and locate-me code paths, where no map
- * tile interaction occurred. When the user clicks directly on the map,
- * VectorGrid already provides these properties from the tile data — no
- * network call is needed.
- *
- * Returns `null` when the region type is {@link InteractiveRegionOption.GRIDDED_DATA}
- * (no feature ID needed), when no matching feature is found, or when the
- * request is aborted.
- *
- * @param regionType - The active interactive region.
- * @param latlng - Coordinates to resolve.
- * @param fetchOptions - Any other options to pass to fetch (ex: `signal`).
- */
-export const fetchRegionFeatureByCoords = async (
-	regionType: InteractiveRegionOption,
-	latlng: Pick<L.LatLng, 'lat' | 'lng'>,
-	fetchOptions?: FetchOptions,
-): Promise<Record<string, unknown> | null> => {
-	const layerName = REGION_TO_WFS_LAYER[regionType];
-	if (!layerName) {
-		return null;
-	}
-
-	type WfsResponse = {
-		features?: { properties?: Record<string, unknown> }[];
-	};
-
-	const data = await fetchJSON<WfsResponse>(
-		`${GEOSERVER_BASE_URL}/geoserver/CDC/ows`,
-		{
-			CQL_FILTER: `CONTAINS(the_geom,POINT(${latlng.lng} ${latlng.lat}))`,
-			maxFeatures: '1',
-			outputFormat: 'application/json',
-			propertyName: 'id,label_en,label_fr',
-			request: 'GetFeature',
-			service: 'WFS',
-			typeName: layerName,
-			version: '1.0.0',
-		},
-		fetchOptions,
-	);
-
-	const properties = data?.features?.[0]?.properties;
-	return properties ?? null;
-};
-
-/**
  * Fetches location data from the API
  *
  * @param latlng Latitude and Longitude of the location


### PR DESCRIPTION
## Description

Pays principal on FI1 — the "synthetic Leaflet click" smell flagged during CLIM-1223 Pass 1. `vectorLayer.fire('click', { latlng })` is not a DOM dispatch; it's a direct procedure call with a fabricated event object, which is why the `featureId` was ever missing in the first place. This branch replaces it with a real `PointerEvent('click')` dispatched on the VectorGrid canvas tile, so VectorGrid's own hit-test resolves the feature exactly as it does for a real user click.

Fixes the same bug CLIM-1223 reported, without the WFS preflight introduced in #671, and additionally covers `recent-locations.tsx` which was on the same synthetic-click pattern.

### How it works

1. `map.setView(latlng, SEARCH_DEFAULT_ZOOM)` centers the target in the viewport.
2. Gate on `moveend` with a 500 ms timeout (`setView` fires `moveend` synchronously on short pans — `once('moveend')` alone hangs).
3. Query the grid pane's canvas elements directly (`gridPane.querySelectorAll('canvas')` + bounding-rect filter — `elementFromPoint` returns the outermost leaflet-container because Leaflet sets `pointer-events: none` on pane wrappers).
4. Dispatch `PointerEvent('click', …)` on the canvas → VectorGrid's own `_onClick` → `handleClick()` → correct `featureId` in `layer.properties`.

No synthetic fallback (broken-escalator rule): if the dispatched event hits nothing, the UI does nothing — matching what a real click at that pixel would do.

### Pass 2 implementation commits (paying principal on FI1), followed by post-wire cleanup below

1. Revert PR #671 (remove WFS preflight).
2. Strip `vectorLayer.fire('click', …)` from both call sites (intermediate state: search navigates but doesn't pop — falsifiable, bisectable).
3. Introduce `apps/src/lib/dispatch-map-click.ts` and wire `search-control.tsx` + `recent-locations.tsx`.

### Post-wire cleanup commits (ticket Session 8 — not behavior-bearing)

- `189a4dd8` — Drop dead `layerRef` prop from `SearchControl` and its `map-container.tsx` call site. Vestige of the pre-D4a vector-layer coupling; no longer needed since DOM dispatch resolves the target via `elementFromPoint` + canvas rect filter.
- `120a09fd` — Refactor `SearchControl` to arrow form with externalized `SearchControlProps`; return type `ReactElement | null` → `ReactElement` (useMap throws, never returns null); drop default `React` import. No behavior change; `tsc -b` clean.

### Verified in browser

`(search | locate-me | recent-locations) × (watershed | census | health)` — correct `featureId` in API URL, popup shows matching data. Gridded mode works via the same path (no special case).

### Why this is Prudent + Deliberate tech-debt work

Pass 1 (#671) paid *interest* on FI1 by working around the smell; this PR pays *principal* by eliminating it. Framing, preconditions, and recurrence count live in the vault TechDebt docs — see the ticket context.

## Related ticket

- CLIM-1223
- Supersedes #671 (merged, then reverted on this branch)