### PR TITLE
CLIM-1371: Fix: dayFormatter incorrectly converts day of year

### DIFF
--- a/apps/src/lib/format.test.ts
+++ b/apps/src/lib/format.test.ts
@@ -2,47 +2,93 @@ import { expect, test, describe } from 'vitest'
 import { doyFormatter, MonthFormat } from './format';
 
 describe('doyFormatter', () => {
-    test('returns correct first day of the year', () => {
-        const output = doyFormatter(0, 'fr-CA');
-        expect(output).toEqual('1 janvier');
+    describe('when 0 corresponds to January 1st', () => {
+        test('returns correct first day of the year', () => {
+            const output = doyFormatter(1, 'fr-CA');
+            expect(output).toEqual('1 janvier');
+        });
+
+        test('returns correct last day of the year', () => {
+            const output = doyFormatter(365, 'fr-CA');
+            expect(output).toEqual('31 décembre');
+        });
+
+        test.each([0, -20])('returns first day if lower than minimum (%s)', (value) => {
+            const output = doyFormatter(value, 'en-CA');
+            expect(output).toEqual('January 1');
+        });
+
+        test.each([366, 890])('returns last day if exceeding (%s)', (value) => {
+            const output = doyFormatter(value, 'en-CA');
+            expect(output).toEqual('December 31');
+        });
+
+        test("doesn't consider the year to be a leap year", () => {
+            // If the year is a leap year, the 60th day would be February 29
+            const output = doyFormatter(60, 'fr-CA');
+            expect(output).toEqual('1 mars');
+        });
+
+        test('outputs in English', () => {
+            const output = doyFormatter(99, 'en-CA');
+            expect(output).toEqual('April 9');
+        });
+
+        test('outputs in French', () => {
+            const output = doyFormatter(101, 'fr-CA');
+            expect(output).toEqual('11 avril');
+        });
+
+        test('default format is "long"', () => {
+            const output_default = doyFormatter(268, 'en-CA');
+            const output_long = doyFormatter(268, 'en-CA', false, 'long');
+            expect(output_default).toEqual(output_long);
+        });
+
+        test.each([
+            ['long', 'April 11'],
+            ['2-digit', '04-11'],
+            // Because of the underlying library used, "2-digit" and "numeric" output the same value
+            ['numeric', '04-11'],
+            ['short', 'Apr 11'],
+            ['narrow', 'A 11'],
+        ])('returns "%s" format', (format, expected) => {
+            const output = doyFormatter(101, 'en-CA', false, format as MonthFormat);
+            expect(output).toEqual(expected);
+        });
     });
-    
-    test('returns correct last day of the year', () => {
-        const output = doyFormatter(364, 'fr-CA');
-        expect(output).toEqual('31 décembre');
-    });
-    
-    test("doesn't consider the year to be a leap year", () => {
-        // If the year is a leap year, the 60th day would be february 29
-        const output = doyFormatter(59, 'fr-CA');
-        expect(output).toEqual('1 mars');
-    });
-    
-    test('outputs in English', () => {
-        const output = doyFormatter(100, 'en-CA');
-        expect(output).toEqual('April 11');
-    });
-    
-    test('outputs in French', () => {
-        const output = doyFormatter(100, 'fr-CA');
-        expect(output).toEqual('11 avril');
-    });
-    
-    test('default format is "long"', () => {
-        const output_default = doyFormatter(268, 'en-CA');
-        const output_long = doyFormatter(268, 'en-CA');
-        expect(output_default).toEqual(output_long);
-    });
-    
-    test.each([
-        ['long', 'April 11'],
-        ['2-digit', '04-11'],
-        // Because of the underlying library used, "2-digit" and "numeric" output the same value
-        ['numeric', '04-11'],
-        ['short', 'Apr 11'],
-        ['narrow', 'A 11'],
-    ])('returns "%s" format', (format, expected) => {
-        const output = doyFormatter(100, 'en-CA', format as MonthFormat);
-        expect(output).toEqual(expected);
+
+    describe('when 0 corresponds to July 1st', () => {
+        test('returns correct first day of the year', () => {
+            const output = doyFormatter(1, 'fr-CA', true);
+            expect(output).toEqual('1 juillet');
+        });
+
+        test('returns correct last day of the year', () => {
+            const output = doyFormatter(365, 'fr-CA', true);
+            expect(output).toEqual('30 juin');
+        });
+
+        test.each([366, 409])('returns last day if exceeding (%s)', (value) => {
+            const output = doyFormatter(value, 'en-CA', true);
+            expect(output).toEqual('June 30');
+        });
+
+        test.each([0, -8])('returns first day if lower than minimum (%s)', (value) => {
+            const output = doyFormatter(value, 'en-CA', true);
+            expect(output).toEqual('July 1');
+        });
+
+        test.each([
+            ['long', 'September 19'],
+            ['2-digit', '09-19'],
+            // Because of the underlying library used, "2-digit" and "numeric" output the same value
+            ['numeric', '09-19'],
+            ['short', 'Sep 19'],
+            ['narrow', 'S 19'],
+        ])('returns "%s" format', (format, expected) => {
+            const output = doyFormatter(81, 'en-CA', true, format as MonthFormat);
+            expect(output).toEqual(expected);
+        });
     });
 });

--- a/apps/src/lib/format.test.ts
+++ b/apps/src/lib/format.test.ts
@@ -2,7 +2,7 @@ import { expect, test, describe } from 'vitest'
 import { doyFormatter, MonthFormat } from './format';
 
 describe('doyFormatter', () => {
-    describe('when 0 corresponds to January 1st', () => {
+    describe('when the first day is January 1st', () => {
         test('returns correct first day of the year', () => {
             const output = doyFormatter(1, 'fr-CA');
             expect(output).toEqual('1 janvier');
@@ -58,7 +58,7 @@ describe('doyFormatter', () => {
         });
     });
 
-    describe('when 0 corresponds to July 1st', () => {
+    describe('when first day is July 1st', () => {
         test('returns correct first day of the year', () => {
             const output = doyFormatter(1, 'fr-CA', true);
             expect(output).toEqual('1 juillet');

--- a/apps/src/lib/format.ts
+++ b/apps/src/lib/format.ts
@@ -133,7 +133,7 @@ export const doyFormatter = (
 	value: number,
 	language: string,
 	firstDayIsJuly: boolean = false,
-	monthFormat: MonthFormat | undefined = 'long',
+	monthFormat: MonthFormat = 'long',
 ) => {
 	const firstMonthOfYear = firstDayIsJuly ? 6 : 0;
 	// First day of the year (UTC). We choose 2018 because neither 2018 nor

--- a/apps/src/lib/format.ts
+++ b/apps/src/lib/format.ts
@@ -112,17 +112,45 @@ export const normalizePostData = async (
 		.filter(Boolean);
 };
 
-export const doyFormatter = (value: number, language: string, monthFormat: MonthFormat | undefined = 'long') => {
-	// First day of the year (UTC)
-	const firstDayOfYear = Date.UTC(2019, 0, 1);
+/**
+ * Format a day of the year number to its localized date.
+ *
+ * @example
+ * ```typescript
+ * doyFormatter(1, 'en-US'); // January 1
+ * doyFormatter(1, 'fr-CA', true); // 1 juillet
+ * doyFormatter(100, 'en-CA', false, 'numeric'); // 04-10
+ * ```
+ *
+ * @param value - The day of the year (first day is 1, not 0!).
+ * @param language - The language code to use for formatting.
+ * @param firstDayIsJuly - If true, the first day of the year will be July 1st,
+ *        else it will be January 1st.
+ * @param monthFormat - The format to use for the month. Defaults to "long".
+ *        The values can be the same as for `Date.toLocaleDateString`.
+ */
+export const doyFormatter = (
+	value: number,
+	language: string,
+	firstDayIsJuly: boolean = false,
+	monthFormat: MonthFormat | undefined = 'long',
+) => {
+	const firstMonthOfYear = firstDayIsJuly ? 6 : 0;
+	// First day of the year (UTC). We choose 2018 because neither 2018 nor
+	// 2019 are leap years.
+	// Reminder: the month's index is 0-based, but the day's index is 1-based.
+	const firstDayOfYear = Date.UTC(2018, firstMonthOfYear, 1);
+	const boundedValue = Math.max(1, Math.min(value, 365));
 
-	// Convert the day-of-year value to a Date object
-	const date = new Date(firstDayOfYear + 1000 * 60 * 60 * 24 * value);
+	// Convert the day-of-year value (1 = first day of the year) to a Date object
+	const millisecondsDelta = (boundedValue - 1) * 1000 * 60 * 60 * 24;
+	const date = new Date(firstDayOfYear + millisecondsDelta);
 
 	// Format the date according to the given language
 	return date.toLocaleDateString(language, {
 		month: monthFormat,
 		day: 'numeric',
+		timeZone: 'UTC',
 	});
 };
 


### PR DESCRIPTION
## Description

This PR fixes 2 issues with the `dayFormatter` function. The two issues generally cancel out, but they should be fixed to prevent issues in the futur.

Also, it adds the possibility to set the first day of the year to "July 1st" instead of "January 1st".

See the description of the Jira ticket for the issue description

## Related ticket

CLIM-1371