### PR TITLE
CLIM-1356: Add new YS-JUL frequency

### DIFF
--- a/apps/src/lib/climate-variable-base.ts
+++ b/apps/src/lib/climate-variable-base.ts
@@ -444,6 +444,12 @@ class ClimateVariableBase implements ClimateVariableInterface {
 		}
 
 		const frequencyCode = getFrequencyType(frequency);
+		let frequencyName = frequency;
+
+		if (frequency === FrequencyType.ANNUAL_JUL_JUN) {
+			// Special case: the YS-JUL and YS have the same frequency name (but different codes)
+			frequencyName = FrequencyType.ANNUAL;
+		}
 
 		const valuesArr = [
 			version,
@@ -458,7 +464,7 @@ class ClimateVariableBase implements ClimateVariableInterface {
 		}
 
 		valuesArr.push(
-			frequency,
+			frequencyName,
 			'30year',
 			this.getDataValue() === 'delta' ? 'delta7100' : ''
 		);

--- a/apps/src/lib/utils.ts
+++ b/apps/src/lib/utils.ts
@@ -68,6 +68,8 @@ export const getFrequencyType = (frequency: string): FrequencyType | undefined =
 
 	if (frequency === 'ann') {
 		frequencyCode = FrequencyType.YS;
+	} else if (frequency === 'annual_jul_jun') {
+		frequencyCode = FrequencyType.YSJUL;
 	} else if (['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'].includes(frequency)) {
 		frequencyCode = FrequencyType.MS;
 	} else if (['spring', 'summer', 'fall', 'winter'].includes(frequency)) {
@@ -95,6 +97,11 @@ export const getDefaultFrequency = (
 	section: string
 ) => {
 	const hasAnnual = isFrequencyEnabled(config, section, FrequencyType.ANNUAL);
+	const hasAnnualJul = isFrequencyEnabled(
+		config,
+		section,
+		FrequencyType.ANNUAL_JUL_JUN,
+	);
 	const hasMonths = isFrequencyEnabled(
 		config,
 		section,
@@ -110,6 +117,8 @@ export const getDefaultFrequency = (
 
 	if (hasAnnual) {
 		defaultValue = FrequencyType.ANNUAL;
+	} else if (hasAnnualJul) {
+		defaultValue = FrequencyType.ANNUAL_JUL_JUN;
 	} else if (hasMonths) {
 		defaultValue = 'jan';
 	} else if (hasSeasons) {
@@ -227,6 +236,7 @@ export const getFeatureId = (properties: {
 export function getUnitName(unit: string): string {
 	switch (unit) {
 		case 'DoY':
+		case 'DoY-jul':
 			return __('Day');
 		case 'degC':
 			return __('°C');

--- a/apps/src/types/climate-variable-interface.ts
+++ b/apps/src/types/climate-variable-interface.ts
@@ -78,6 +78,7 @@ export enum FrequencyType {
 	ALL_MONTHS = 'allMonths',
 	DAILY = 'daily',
 	YS = 'ys',
+	YSJUL = 'ysjul',
 	MS = 'ms',
 	QSDEC = 'qsdec',
 }
@@ -95,6 +96,7 @@ export const FrequencyTypes = {
 	DAILY: FrequencyType.DAILY,
 	// Frequency types for API and GeoServer queries.
 	YS: FrequencyType.YS,
+	YSJUL: FrequencyType.YSJUL,
 	MS: FrequencyType.MS,
 	QSDEC: FrequencyType.QSDEC,
 } as const;


### PR DESCRIPTION
## Description

Add the new YS-JUL frequency and make sure the code that works with frequencies are updated.

Note that for Finch variables, there is already an `ANNUAL_JUL_JUN` frequency, but this frequency was not supported for pre-calculated variables and the Map page. This PR adds it.

## Related ticket

CLIM-1356
