### PR TITLE
CLIM-1322 (2): Map popup name resolution — server-side rewrite + dispatchMapClick refactor

### DIFF
--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -95,7 +95,9 @@ const SearchControl = ({
 
 	const handleLocationChange = useCallback(
 		async (inputLatlng: SearchLatLng) => {
+			console.log('RBx 2a\thandleLocationChange useCallback inputLatlng\n', inputLatlng)
 			const latlng = convertSearchLatLng(inputLatlng);
+			console.log('RBx 3a\thandleLocationChange useCallback convertSearchLatLng(inputLatlng)\n', latlng)
 			// clear all existing markers from the map
 			map.eachLayer(layer => {
 				if (layer instanceof L.Marker) {
@@ -189,7 +191,7 @@ const SearchControl = ({
 		// @ts-expect-error: suppress leaflet typescript error
 		const searchControl = new L.Control.Search({
 			url: LOCATION_SEARCH_ENDPOINT,
-			propertyLoc: ['lat', 'lng'],
+			propertyLoc: ['lat', 'lng'], // What this is for? And Where is this used?
 			autoResize: false,
 			collapsed: false,
 			autoCollapse: false,
@@ -203,12 +205,30 @@ const SearchControl = ({
 					SearchControlLocationItem & { loc: number[]; lng: string; }
 				> = {};
 
+				console.log('RBx 0a\tL.Control.Search({ formatData })\n', response?.items );
+
+				/**
+				 * ```js
+				 * response.items = [
+				 *   {
+         *     "id": "EHHUN",
+         *     "text": "Montréal",
+         *     "term": "Ville",
+         *     "location": "Montréal; Montréal",
+         *     "province": "Québec",
+         *     "lat": "45.508822",
+         *     "lon": "-73.554077"
+         *   }
+				 * ]
+				 * ```
+				 */
+
 				response.items.forEach((item: SearchControlLocationItem) => {
 					const title = buildLocationTitle(item);
 					const loc = [parseFloat(item.lat), parseFloat(item.lon)];
 					formattedData[title] = {
 						...item,
-						lng: item.lon,
+						lng: item.lon, // Ah, here
 						loc,
 					};
 				});
@@ -228,10 +248,12 @@ const SearchControl = ({
 				}
 				// Check if the coordinates are valid if the location is empty.
 				const latLng = parseLatLon(this._input.value);
+				console.log('RBx 4a\tL.Control.Search({ locationNotFound }) will call fetchLocationByCoords\n', this._input );
 				// If the coordinates are valid, move to that location.
 				if (latLng && !latLng.isPartial) {
 					// Fetch location data
-					const locationByCoords = await fetchLocationByCoords({ lat: latLng.lat, lng: latLng.lon });
+					// /wp-json/cdc/v2/get_location_by_coords?lat=45.509234158692905&lng=-73.55346679687501
+					const locationByCoords = await fetchLocationByCoords({ lat: latLng.lat, lng: latLng.lon }); //
 					// Trigger show location.
 					this.showLocation(locationByCoords, locationByCoords.title);
 				}
@@ -249,6 +271,7 @@ const SearchControl = ({
 				}),
 			}),
 			moveToLocation: (latlng: SearchLatLng) => {
+				console.log('RBx 1a\tmoveToLocation\thandleLocationChange(latlng)\n', latlng);
 				handleLocationChange(latlng);
 			},
 		});

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -21,7 +21,7 @@ import 'leaflet-search';
 import mapPinIcon from '@/assets/map-pin.svg';
 
 import { cn, parseLatLon } from '@/lib/utils';
-import { dispatchMapClick } from '@/lib/dispatch-map-click';
+import { moveAndPointAt } from '@/lib/move-and-point-at';
 import { fetchLocationByCoords } from '@/services/services';
 import {
 	type SearchControlLocationItem,
@@ -29,7 +29,6 @@ import {
 } from '@/types/types';
 import {
 	LOCATION_SEARCH_ENDPOINT,
-	SEARCH_DEFAULT_ZOOM,
 	SEARCH_PLACEHOLDER,
 } from '@/lib/constants';
 
@@ -103,8 +102,7 @@ const SearchControl = ({
 					map.removeLayer(layer);
 				}
 			});
-			map.setView(latlng, SEARCH_DEFAULT_ZOOM);
-			await dispatchMapClick(map, latlng);
+			await moveAndPointAt(map, latlng);
 		},
 		[
 			map,

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -235,7 +235,7 @@ const SearchControl = ({
 					// Fetch location data
 					const locationByCoords = await fetchLocationByCoords({ lat: latLng.lat, lng: latLng.lon });
 					// Trigger show location.
-					this.showLocation(locationByCoords, locationByCoords.geo_id);
+					this.showLocation(locationByCoords, locationByCoords.title);
 				}
 				else {
 					// Show error alert.

--- a/apps/src/components/sidebar-footer-links/recent-locations.tsx
+++ b/apps/src/components/sidebar-footer-links/recent-locations.tsx
@@ -14,8 +14,7 @@ import { SidebarPanel } from '@/components/ui/sidebar';
 // other
 import { useAppSelector } from '@/app/hooks';
 import { MapLocation } from '@/types/types';
-import { SEARCH_DEFAULT_ZOOM } from '@/lib/constants';
-import { dispatchMapClick } from '@/lib/dispatch-map-click';
+import { moveAndPointAt } from '@/lib/move-and-point-at';
 import { useMap } from '@/hooks/use-map';
 import { useSidebar } from '@/hooks/use-sidebar';
 import { cn } from '@/lib/utils';
@@ -61,8 +60,7 @@ const RecentLocationsPanel: React.FC = () => {
 	}
 
 	const moveToLocation = async (location: MapLocation) => {
-		map.setView(location, SEARCH_DEFAULT_ZOOM);
-		await dispatchMapClick(map, location);
+		await moveAndPointAt(map, location);
 	};
 
 	return (

--- a/apps/src/hooks/use-map-interactions.tsx
+++ b/apps/src/hooks/use-map-interactions.tsx
@@ -71,6 +71,8 @@ export function useMapInteractions({ primaryLayerRef, comparisonLayerRef }: UseM
 
     const interactiveRegion = climateVariable?.getInteractiveRegion() ?? InteractiveRegionOption.GRIDDED_DATA;
 
+		console.log('RBx 5a\thandleClick (will call fetchLocationByCoords)\n', latlng);
+
     const locationByCoords = await fetchLocationByCoords(latlng);
     const locationId = locationByCoords?.geo_id ?? `${locationByCoords?.lat}|${locationByCoords?.lng}`;
     let locationTitle = locationByCoords.title;

--- a/apps/src/hooks/use-map-interactions.tsx
+++ b/apps/src/hooks/use-map-interactions.tsx
@@ -8,6 +8,7 @@ import { useMapMarker } from '@/hooks/use-map-marker';
 import { useLocale } from '@/hooks/use-locale';
 import { fetchLocationByCoords } from '@/services/services';
 import { getFeatureId } from '@/lib/utils';
+import { consumeIntendedLatlng } from '@/lib/move-and-point-at';
 import { SelectedLocationInfo } from '@/types/types';
 import { InteractiveRegionOption } from "@/types/climate-variable-interface";
 
@@ -66,7 +67,29 @@ export function useMapInteractions({ primaryLayerRef, comparisonLayerRef }: UseM
     hoveredRef.current = null;
   }, [primaryLayerRef, comparisonLayerRef]); // No dependencies since we're only using refs via .current
 
-  const handleClick = useCallback(async ({ latlng, layer }: { latlng: L.LatLng; layer: { properties: any } }) => {
+  const handleClick = useCallback(async (
+    e: {
+      latlng: L.LatLng;
+      layer: { properties: any };
+      // `target` is the vectorgrid layer the click was bound to. Leaflet
+      // attaches `_map` to layers on `addTo(map)`. Underscored but stable —
+      // we need the map handle here to consume any "intended latlng" the
+      // search/recent-locations flows stashed before the synthetic click.
+      target?: { _map?: L.Map };
+    },
+  ) => {
+    const eventLatlng = e.latlng;
+    const layer = e.layer;
+    const map = e.target?._map ?? null;
+    // Recover the precise caller-supplied latlng if this click originated
+    // from `moveAndPointAt`'s synthetic dispatch — Leaflet rebuilds `latlng`
+    // from rounded container pixels, dropping ~80 m of precision (CLIM-1322).
+    // One-shot read; falls through to the event latlng for real user clicks.
+    const intendedLatlng = map !== null
+      ? consumeIntendedLatlng(map)
+      : null;
+    const latlng = intendedLatlng ?? eventLatlng;
+
     const featureId = layer && getFeatureId(layer.properties);
 
     const interactiveRegion = climateVariable?.getInteractiveRegion() ?? InteractiveRegionOption.GRIDDED_DATA;

--- a/apps/src/lib/move-and-point-at.ts
+++ b/apps/src/lib/move-and-point-at.ts
@@ -3,6 +3,42 @@ import L from 'leaflet';
 import { SEARCH_DEFAULT_ZOOM } from '@/lib/constants';
 
 /**
+ * Per-map "intended latlng" channel.
+ *
+ * Producers (search, recent-locations, locate-me) know the precise lat/lng
+ * the user expressed before we synthesise a click. The synthetic click round-
+ * trips through `latLngToContainerPoint` → integer pixels → `containerPointToLatLng`
+ * inside Leaflet's downstream click handler, which drops sub-pixel precision
+ * (~80 m drift at typical zooms — enough to land on the wrong gridded-data row
+ * for popup titles; see CLIM-1322).
+ *
+ * The fix: stash the intended latlng keyed by `L.Map` instance just before
+ * dispatching the synthetic click; the consumer (`useMapInteractions.handleClick`)
+ * reads-and-deletes it via {@link consumeIntendedLatlng}. The read is one-shot
+ * so a stale value cannot bleed into a later real user click. `WeakMap` keying
+ * on the map instance lets entries get GC'd with the map, no leak.
+ *
+ * Producer side is owned by {@link moveAndPointAt} (the only path that creates
+ * the synthetic click), so callers don't need to opt in.
+ */
+const _intendedLatlngByMap = new WeakMap<L.Map, L.LatLng>();
+
+/**
+ * Read-and-delete the intended latlng for a map, if any was set by a recent
+ * {@link moveAndPointAt} synthetic-click dispatch. One-shot by design — see
+ * the module comment on `_intendedLatlngByMap`.
+ */
+export const consumeIntendedLatlng = (
+	map: L.Map,
+): L.LatLng | null => {
+	const latlng = _intendedLatlngByMap.get(map) ?? null;
+	if (latlng !== null) {
+		_intendedLatlngByMap.delete(map);
+	}
+	return latlng;
+};
+
+/**
  * Moves the map to a specific lat/lng and triggers the location-selection
  * cascade at that point.
  *
@@ -18,6 +54,10 @@ import { SEARCH_DEFAULT_ZOOM } from '@/lib/constants';
  * `Promise.race` with a 1,000 ms timeout guards the case where `setView`
  * fires `moveend` synchronously (short pan, no animation) before the
  * listener is attached.
+ *
+ * The intended `latlng` is stashed via the per-map channel above so the
+ * downstream click consumer can recover the precise coordinate instead of
+ * the lossy pixel-rounded one Leaflet rebuilds from the synthetic event.
  */
 export const moveAndPointAt = async (
 	map: L.Map,
@@ -55,6 +95,12 @@ export const moveAndPointAt = async (
 		);
 	}) ?? null;
 	if (target) {
+		// Preserve the precise caller-supplied latlng across the synthetic
+		// click's pixel round-trip — see `_intendedLatlngByMap` doc above.
+		const intended = latlng instanceof L.LatLng
+			? latlng
+			: L.latLng(latlng.lat, latlng.lng);
+		_intendedLatlngByMap.set(map, intended);
 		target.dispatchEvent(new PointerEvent('click', {
 			bubbles: true,
 			cancelable: true,

--- a/apps/src/lib/move-and-point-at.ts
+++ b/apps/src/lib/move-and-point-at.ts
@@ -39,6 +39,11 @@ export const moveAndPointAt = async (
 	if (!gridPane) {
 		return;
 	}
+	// `pointer-events: none` on Leaflet's pane wrapper divs causes
+	// `document.elementFromPoint` to return the outermost container — the
+	// canvas tiles themselves are not hit-testable through that API. We
+	// enumerate the grid pane's canvases and filter by their bounding rect
+	// to find the one under (clientX, clientY) instead.
 	const canvases = Array.from(gridPane.querySelectorAll('canvas'));
 	const target = canvases.find((canvas) => {
 		const r = canvas.getBoundingClientRect();

--- a/apps/src/lib/move-and-point-at.ts
+++ b/apps/src/lib/move-and-point-at.ts
@@ -1,23 +1,30 @@
 import L from 'leaflet';
 
+import { SEARCH_DEFAULT_ZOOM } from '@/lib/constants';
+
 /**
- * Dispatches a real DOM PointerEvent on the VectorGrid canvas tile at the
- * map container center after the view settles.
+ * Moves the map to a specific lat/lng and triggers the location-selection
+ * cascade at that point.
  *
- * `pointer-events: none` on Leaflet's pane wrapper divs causes
- * `document.elementFromPoint` to return the outermost container — canvas
- * tiles are queried via `gridPane.querySelectorAll('canvas')` and filtered
- * by bounding rect instead.
+ * Used by the search and locate-me flows: the user expressed where they
+ * want to go, this function drives the map there and triggers the same
+ * downstream effects as a manual click would.
+ *
+ * The click-on-canvas dispatch is an implementation detail — VectorGrid's
+ * click handler is what triggers fetchLocationByCoords + popup open, so we
+ * synthesise a real DOM PointerEvent at the typed lat/lng's screen
+ * coordinates.
  *
  * `Promise.race` with a 1,000 ms timeout guards the case where `setView`
  * fires `moveend` synchronously (short pan, no animation) before the
  * listener is attached.
  */
-export const dispatchMapClick = async (
+export const moveAndPointAt = async (
 	map: L.Map,
-	latlng: { lat: number; lng: number },
+	latlng: L.LatLng | { lat: number; lng: number },
+	zoom: number = SEARCH_DEFAULT_ZOOM,
 ): Promise<void> => {
-	void latlng;
+	map.setView(latlng, zoom);
 	await Promise.race([
 		new Promise<void>((resolve) => map.once('moveend', () => resolve())),
 		new Promise<void>((resolve) => setTimeout(resolve, 1_000)),
@@ -25,8 +32,9 @@ export const dispatchMapClick = async (
 	await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 	const container = map.getContainer();
 	const rect = container.getBoundingClientRect();
-	const clientX = rect.left + rect.width / 2;
-	const clientY = rect.top + rect.height / 2;
+	const point = map.latLngToContainerPoint(latlng);
+	const clientX = rect.left + point.x;
+	const clientY = rect.top + point.y;
 	const gridPane = map.getPane('grid') ?? null;
 	if (!gridPane) {
 		return;

--- a/fw-child/resources/functions/rest.php
+++ b/fw-child/resources/functions/rest.php
@@ -379,104 +379,40 @@ function cdc_get_location_by_coords () {
 				$join = "JOIN all_areas_sealevel ON (all_areas.id_code=all_areas_sealevel.id_code)";
 			}
 
-			$ranges = [ 0.05, 0.1, 0.2 ];
-			$preferred_terms = [ 'Community', 'Metropolitan Area' ];
-			$found_community = false;
+			// Single nearest-neighbour lookup, eligibility set harmonised with cdc_location_search()
+			// so search and click return the same name space (CLIM-1322; client clarification 2026-04-17).
+			$range = 0.2;
 
-			// gradually increase the range until we find a community
+			$main_query = mysqli_query($GLOBALS['vars']['con'], "SELECT " . implode(",", $columns) . "
+			, DISTANCE_BETWEEN($lat, $lng, lat,lon) as distance
+			FROM all_areas
+			$join
+			WHERE lat BETWEEN " . (round($lat, 2) - $range) . " AND " . (round($lat, 2) + $range) . "
+			AND lon BETWEEN " . (round($lng, 2) - $range) . " AND " . (round($lng, 2) + $range) . "
+			AND gen_term NOT IN ('Administrative Region', 'Province', 'Territory')
+			ORDER BY DISTANCE
+			LIMIT 1");
 
-			foreach ( $ranges as $range ) {
+			if ($main_query->num_rows > 0) {
 
-				if ( $found_community == false ) {
-					$main_query = mysqli_query($GLOBALS['vars']['con'], "SELECT " . implode(",", $columns) . "
-					, DISTANCE_BETWEEN($lat, $lng, lat,lon) as distance
-					FROM all_areas
-					$join
-					WHERE lat BETWEEN " . (round($lat, 2) - $range) . " AND " . (round($lat, 2) + $range) . "
-					AND lon BETWEEN " . (round($lng, 2) - $range) . " AND " . (round($lng, 2) + $range) . "
-					AND gen_term NOT IN ('Railway Point', 'Railway Junction', 'Urban Community', 'Administrative Sector')
-					ORDER BY DISTANCE
-					LIMIT 50");// or die (mysqli_error($GLOBALS['vars']['con']));
+				$result = mysqli_fetch_assoc ( $main_query );
 
-					if ($main_query->num_rows > 0) {
+				$result['coords'] = [ $lat, $lng ];
+				$result['lng'] = $result['lon'];
+				$result['province_short'] = short_province ( $result['province'] );
+				$result['title'] = $result['geo_name'] . ', ' . $result['province_short'];
 
-						while ( $row = mysqli_fetch_assoc ( $main_query ) ) {
-
-							if ( in_array ( $row['generic_term'], $preferred_terms ) ) {
-								$result = $row;
-
-								// might be good to know
-								// what range is the community in from the click
-								$result['range'] = $range;
-
-								// send back the original coords
-								$result['coords'] = [ $lat, $lng ];
-
-								// lon -> lng
-								$result['lng'] = $result['lon'];
-
-								// province abbreviation
-								$result['province_short'] = short_province ( $result['province'] );
-
-								// nice name
-								$result['title'] = $result['geo_name'] . ', ' . $result['province_short'];
-
-								$found_community = true;
-
-								break;
-							}
-						}
-
-					}
-
-				}
-
-			}
-
-			if ( $found_community == true ) {
-
-				// found a community in range
 				echo json_encode ( $result );
 
 			} else {
 
-				// no preferred results, grab the nearest one
-
-				// range of coordinates to search between
-				$range = 0.1;
-
-				$main_query = mysqli_query($GLOBALS['vars']['con'], "SELECT " . implode(",", $columns) . "
-				, DISTANCE_BETWEEN($lat, $lng, lat,lon) as distance
-				FROM all_areas
-				$join
-				WHERE lat BETWEEN " . (round($lat, 2) - $range) . " AND " . (round($lat, 2) + $range) . "
-				AND lon BETWEEN " . (round($lng, 2) - $range) . " AND " . (round($lng, 2) + $range) . "
-				AND gen_term NOT IN ('Railway Point', 'Railway Junction', 'Urban Community', 'Administrative Sector')
-				ORDER BY DISTANCE
-				LIMIT 1");// or die (mysqli_error($GLOBALS['vars']['con']));
-
-				if ($main_query->num_rows > 0) {
-
-					$result = mysqli_fetch_assoc ( $main_query );
-
-					$result['coords'] = [ $lat, $lng ];
-					$result['lng'] = $result['lon'];
-					$result['province_short'] = short_province ( $result['province'] );
-					$result['title'] = $result['geo_name'] . ', ' . $result['province_short'];
-
-					echo json_encode ( $result );
-
-				} else {
-
-					echo json_encode ( array (
-						'lat' => $lat,
-						'lng' => $lng,
-						'coords' => [ $lat, $lng ],
-						'geo_name' => __ ( 'Point', 'cdc' ),
-						'title' => __ ( 'Point', 'cdc' ) . ' (' . number_format ( $lat, 4, '.', '') . ', ' . number_format ( $lng, 4, '.', '') . ')'
-					) );
-
-				}
+				echo json_encode ( array (
+					'lat' => $lat,
+					'lng' => $lng,
+					'coords' => [ $lat, $lng ],
+					'geo_name' => __ ( 'Point', 'cdc' ),
+					'title' => __ ( 'Point', 'cdc' ) . ' (' . number_format ( $lat, 4, '.', '') . ', ' . number_format ( $lng, 4, '.', '') . ')'
+				) );
 
 			}
 

--- a/fw-child/resources/functions/rest.php
+++ b/fw-child/resources/functions/rest.php
@@ -389,7 +389,7 @@ function cdc_get_location_by_coords () {
 			$join
 			WHERE lat BETWEEN " . (round($lat, 2) - $range) . " AND " . (round($lat, 2) + $range) . "
 			AND lon BETWEEN " . (round($lng, 2) - $range) . " AND " . (round($lng, 2) + $range) . "
-			AND gen_term NOT IN ('Administrative Region', 'Province', 'Territory')
+			AND gen_term NOT IN ('Administrative Region', 'Census Division', 'Province', 'Territory')
 			ORDER BY DISTANCE
 			LIMIT 1");
 

--- a/fw-child/resources/functions/rest.php
+++ b/fw-child/resources/functions/rest.php
@@ -389,7 +389,7 @@ function cdc_get_location_by_coords () {
 			$join
 			WHERE lat BETWEEN " . (round($lat, 2) - $range) . " AND " . (round($lat, 2) + $range) . "
 			AND lon BETWEEN " . (round($lng, 2) - $range) . " AND " . (round($lng, 2) + $range) . "
-			AND gen_term NOT IN ('Administrative Region', 'Census Division', 'Province', 'Territory')
+			AND gen_term NOT IN ('Administrative Region', 'Census Division', 'Census Subdivision', 'Province', 'Territory')
 			ORDER BY DISTANCE
 			LIMIT 1");
 

--- a/fw-child/resources/functions/rest.php
+++ b/fw-child/resources/functions/rest.php
@@ -389,7 +389,32 @@ function cdc_get_location_by_coords () {
 			$join
 			WHERE lat BETWEEN " . (round($lat, 2) - $range) . " AND " . (round($lat, 2) + $range) . "
 			AND lon BETWEEN " . (round($lng, 2) - $range) . " AND " . (round($lng, 2) + $range) . "
-			AND gen_term NOT IN ('Administrative Region', 'Census Division', 'Census Subdivision', 'Province', 'Territory')
+			AND gen_term NOT IN (
+				'Administrative Region',
+				'Administrative Sector',
+				'Census Division',
+				'Census Subdivision',
+				'County',
+				'County Municipality',
+				'County Regional Municipality',
+				'District Municipality',
+				'Improvement District',
+				'Local Government District',
+				'Local Service District',
+				'Local Urban District',
+				'Municipal County',
+				'Municipal District',
+				'Municipality',
+				'Province',
+				'Region',
+				'Regional District',
+				'Regional Municipality',
+				'Restructured County',
+				'Specialized Municipality',
+				'Subdivision',
+				'Territory',
+				'Unorganized Territory'
+			)
 			ORDER BY DISTANCE
 			LIMIT 1");
 

--- a/fw-child/resources/functions/rest.php
+++ b/fw-child/resources/functions/rest.php
@@ -367,7 +367,7 @@ function cdc_get_location_by_coords () {
 				"geo_name",
 				"gen_term" . $term_append . " as generic_term",
 				"location",
-				"province" . $term_append,
+				"province" . $term_append . " as province",
 				"lat",
 				"lon"
 			);


### PR DESCRIPTION
**Popup Title Display Discrepancy When InteractiveRegionOption.GRIDDED_DATA**

- **See:** #685

Related:
- #674 
- #682 
- #684

WIP

## Summary

Rewrites `cdc_get_location_by_coords()` and refactors `dispatchMapClick` so the map popup title and pin position match what the user asked for, across all four entry paths (autocomplete selection, raw `lat,lng` paste, locate-me, manual map click) and both languages.

## What was wrong

Per the original report and clarifications we've established back around 2026-04-17:

- **Search "Vancouver" → popup says "Mount Pleasant"** (a Vancouver neighbourhood). Same shape on Toronto → North York. Caused by the server's `cdc_get_location_by_coords()` two-pass loop: it first filtered candidate rows to `gen_term IN ('Community','Metropolitan Area')` and only fell through to a broader query when that failed. Search and click ran through the same endpoint and produced different name spaces because the click-side filter excluded rows autocomplete returned.
- **Raw `lat,lng` paste snaps to the nearest DB row**: typing `44.646445,-63.619798` (slightly West of Halifax) sent the marker to `44.647650,-63.590240` instead. Two distinct user inputs collapsed to the same response.
- **FR popup titles end with a trailing comma**: `"Sainte-Adèle, "`, `"Victoria, "`. The PHP function selected `province_fr` via column-name concatenation but never aliased the returned column back to the `province` key, so `$result['province']` was undefined in FR. `province_short` came out `null` and the `title` slot for the province abbreviation was empty.
- **Search-bar selection produces a popup at a slightly-drifted coord**: `dispatchMapClick(map, latlng)` dropped its `latlng` argument (literally `void latlng;`) and dispatched the synthetic click at the container's centre. After `setView(latlng)` tile-snapped, the centre's actual lat/lng was off the typed value by 30–120 m — observable as the Session 8 DoD-2 coord-drift hypothesis.
- **Raw-coord popups display an opaque 5-character string** (`EJK8O`, `EPYTF`, …) instead of a place name. The `locationNotFound` branch passed `locationByCoords.geo_id` to `showLocation` as the title argument; the server already returned a human-readable `title` field, but it wasn't being used.

## What this changes

Eight atomic commits on `CLIM-1322_2_Popup-Title-Name-Resolution`, one per concrete change:

1. **Alias `province_fr` back to `province`** in `cdc_get_location_by_coords()` SELECT — matches the pattern already used by `cdc_get_location_by_id()` in the same file. Fixes the trailing-comma title.
2. **Drop the `preferred_terms` two-pass; harmonise `gen_term` exclusion with `cdc_location_search()`** (`('Administrative Region','Province','Territory')`). Single nearest-neighbour query at range 0.2°. Fixes the Vancouver/Toronto and Victoria search/click name divergence.
3. **Use `locationByCoords.title` for raw-coord popup, not `geo_id`** in `apps/src/components/map-layers/search-control.tsx`'s `locationNotFound` branch. Fixes the opaque 5-char popup title.
4. **Add `Census Division` to the `gen_term` exclusion** — first attempt at the Sainte-Adèle case where the Town and the Census Division share centroid coords.
5. **Add `Census Subdivision` to the `gen_term` exclusion** — same family.
6. **Rename `dispatchMapClick` → `moveAndPointAt`; honour the typed `lat/lng`** — the function now takes responsibility for `setView` (folded in) and computes the synthetic click's `clientX`/`clientY` via `map.latLngToContainerPoint(latlng)` so the click fires at the typed coord, not the tile-snapped centre. Both call sites updated. The "dispatch click" framing was the implementation detail; the new name describes the purpose.
7. **Broaden the `gen_term` exclusion to drop all administrative-grouping rows** — adds `County`, `County Regional Municipality`, all variants of `*Municipality`, `*District`, `Region`, `Regional District`, `Subdivision`, `Unorganized Territory`, plus `Administrative Sector` (lost from the original 4-term exclusion in the previous harmonisation step). None of these are place names a user types into a search bar to find a specific spot. Resolves Sainte-Adèle.
8. **Restore the canvas-vs-`elementFromPoint` workaround comment** as an inline code comment near the canvas-enumeration block — the original JSDoc carried the explanation; it was dropped during the rename refactor and restored where it actually applies.

## Why these specific changes

Carrington's reply collapsed the (mode × entry path) ambiguity matrix — search and click must return the same names; raw `lat,lng` must keep the typed coords. The fix needed to be at the server, not in the client's title plumbing. An earlier illustration (PR #674, draft) tried passing the autocomplete title through to the popup via a `searchProvidedTitle` argument; the present PR replaces that approach. The server-side rewrite reaches the click-on-map path that no client-side title plumbing could reach, and matches behaviour across the autocomplete, raw-coord-paste, and locate-me paths because they all go through the same endpoint.

The exclusion list grew through three iterations because the data has multiple administrative-grouping rows at city centroids — Census Division (Atom 4), Census Subdivision (Atom 5), then County Regional Municipality and others (Atom 7). Each step was driven by what the data actually returned at the verification anchors. The autocomplete-only filter (Atom 2's exclusion of just `Administrative Region`/`Province`/`Territory`) was sufficient for major cities (Toronto, Vancouver, Halifax) but not for towns whose centroid coincides with their administrative parent (Sainte-Adèle).

The `dispatchMapClick` refactor was on the same path: the function existed to bridge "the user said they want to go here" with "trigger the same cascade as a manual click would", but it had been dropping the `latlng` argument and approximating the destination via the container centre. The Session 8 coord-drift was one symptom; Renoir flagged it independently this session as a "the name is a misnomer" observation about the function's purpose vs its name.

## Verification

API-level probes against `dev-en` and `dev-fr` (raw HTTP, JSON parse, no Xdebug pollution observed in any probe):

| Anchor | Pre-fix | Post-fix |
|---|---|---|
| Vancouver search-by-name | `Mount Pleasant, BC` | `Vancouver, BC` |
| Toronto search-by-name | `North York, ON` | `Toronto, ON` |
| Sainte-Adèle search-by-name | `Les Pays-d'en-Haut,` | `Sainte-Adèle, QC` |
| Victoria search-by-name (EN) | `Fairfield, BC` | `Victoria, BC` |
| Victoria search-by-name (FR) | `Victoria,` (trailing comma) | `Victoria, BC` |
| Halifax raw-coord centre | `Halifax, NS` (unchanged) | `Halifax, NS` |
| Halifax raw-coord West offset | `Halifax, NS` (snap — original client complaint) | `Chocolate Lake, NS` (no snap; `coords` carries typed coords back) |

Click-precision spot-checks (5–10 km offsets from city centroids) confirm clicks far from a city return locally-appropriate places, not the city — exactly the behaviour the wide 0.2° bounding box was a theoretical concern about. The bounding box is a SQL optimisation; `ORDER BY DISTANCE LIMIT 1` finds the truly-nearest allowed row.

## Known limitations / not done

- **Browser-level UAT pending** — the API path is verified end-to-end; the visual marker placement after Atom 6's coord-precision fix and the popup-rendering path have not been exercised in a real browser run.
- **`Urban Community` / `Railway Point` / `Railway Junction` rows are now reachable** through the click path (the original 4-term exclusion no longer applies). Empirically: a click in downtown Toronto can land on `Cabbagetown, ON` (`Urban Community`) instead of `Toronto, ON` because Cabbagetown's stored centroid is closer to the click. Within Carrington's "match autocomplete" directive, but flagged for domain-expert review on whether it's the desired behaviour for `InteractiveRegionOption.GRID` map clicks.
- **Xdebug suppression on dev for `cdc/v2` endpoints** (Slice C, separable) — not addressed. Tracked as T23.
- **EN/FR parallel-WebKit comparison workflow lift** (T25, LEARN phase) — not addressed.
- **Popup "(sometimes) doesn't open" intermittent timing** — observed during Session 8, not investigated this session. Past notes from a prior session may have a path; deferred.
- **Stakeholder direction on explicit-typing of admin-grouping names** — if a user explicitly types "Les Pays-d'en-Haut" expecting that exact popup, the broadened exclusion now returns the nearest non-grouping place at the centroid. Honouring "show what was typed verbatim" requires passing the autocomplete row's `id_code` through to a fetch-by-id, which is the architectural change descoped in the analysis plan as D1c (preserved as TechDebt FI1).

## What this does not touch

Frozen historical artefact: branch `CLIM-1322_Popup-Title-Name-Resolution` and its draft PR #674. Not amended, not pushed, not closed — preserved per Renoir's instruction.

## Documentation

- [[LLM-Context-ClimateData-Ticket-CLIM-1322#Session 9]] — work session narrative, files modified, verification matrix.
- [[LLM-Context-ClimateData-Ticket-CLIM-1322-Analysis-Plan#D4]] — filter-list shape decision (D4b broader admin-grouping list picked).
- [[LLM-Context-ClimateData-Ticket-CLIM-1322-Analysis-Plan#D5]] — moveAndPointAt refactor decision (D5b rename+fold+honour-latlng picked).
- New CIs added to the analysis plan: CI-17 (dispatchMapClick latlng-discard), CI-18 (`all_areas` schema audit), CI-19 (Sainte-Adèle admin-grouping coord-tie), CI-20 (Halifax raw-coord post-fix behaviour).