### PR TITLE
CLIM-1376: dayFormatter: Support values outside the range [0, 365]

### DIFF
--- a/apps/src/lib/format.test.ts
+++ b/apps/src/lib/format.test.ts
@@ -13,15 +13,24 @@ describe('doyFormatter', () => {
             expect(output).toEqual('31 décembre');
         });
 
-        test.each([0, -20])('returns first day if lower than minimum (%s)', (value) => {
+        test.each([
+            [0, 'December 31'],
+            [-1, 'December 30'],
+            [-42, 'November 19'],
+            [-364, 'January 1'], // Minimum of the recommended range
+        ])('works with value below 1 (%s)', (value, expected) => {
             const output = doyFormatter(value, 'en-CA');
-            expect(output).toEqual('January 1');
+            expect(output).toEqual(expected);
         });
 
-        test.each([366, 890])('returns last day if exceeding (%s)', (value) => {
-            const output = doyFormatter(value, 'en-CA');
-            expect(output).toEqual('December 31');
-        });
+    test.each([
+        [366, 'January 1'],
+        [417, 'February 21'],
+        [730, 'December 31'], // Maximum of the recommended range
+    ])('works with value above 365 (%s)', (value, expected) => {
+        const output = doyFormatter(value, 'en-CA');
+        expect(output).toEqual(expected);
+    });
 
         test("doesn't consider the year to be a leap year", () => {
             // If the year is a leap year, the 60th day would be February 29
@@ -69,15 +78,24 @@ describe('doyFormatter', () => {
             expect(output).toEqual('30 juin');
         });
 
-        test.each([366, 409])('returns last day if exceeding (%s)', (value) => {
+        test.each([
+            [0, 'June 30'],
+            [-1, 'June 29'],
+            [-42, 'May 19'],
+            [-364, 'July 1'], // Minimum of the recommended range
+        ])('works with value below 1 (%s)', (value, expected) => {
             const output = doyFormatter(value, 'en-CA', true);
-            expect(output).toEqual('June 30');
+            expect(output).toEqual(expected);
         });
 
-        test.each([0, -8])('returns first day if lower than minimum (%s)', (value) => {
-            const output = doyFormatter(value, 'en-CA', true);
-            expect(output).toEqual('July 1');
-        });
+        test.each([
+            [366, 'July 1'],
+            [417, 'August 21'],
+            [730, 'June 30'], // Maximum of the recommended range
+        ])('works with value above 365 (%s)', (value, expected) => {
+        const output = doyFormatter(value, 'en-CA', true);
+        expect(output).toEqual(expected);
+    });
 
         test.each([
             ['long', 'September 19'],

--- a/apps/src/lib/format.test.ts
+++ b/apps/src/lib/format.test.ts
@@ -17,7 +17,7 @@ describe('doyFormatter', () => {
             [0, 'December 31'],
             [-1, 'December 30'],
             [-42, 'November 19'],
-            [-364, 'January 1'], // Minimum of the recommended range
+            [-1708, 'April 27'],  // At least 4 years to ensure no issue with leap years
         ])('works with value below 1 (%s)', (value, expected) => {
             const output = doyFormatter(value, 'en-CA');
             expect(output).toEqual(expected);
@@ -26,7 +26,7 @@ describe('doyFormatter', () => {
     test.each([
         [366, 'January 1'],
         [417, 'February 21'],
-        [730, 'December 31'], // Maximum of the recommended range
+        [1708, 'September 5'], // At least 4 years to ensure no issue with leap years
     ])('works with value above 365 (%s)', (value, expected) => {
         const output = doyFormatter(value, 'en-CA');
         expect(output).toEqual(expected);
@@ -82,7 +82,7 @@ describe('doyFormatter', () => {
             [0, 'June 30'],
             [-1, 'June 29'],
             [-42, 'May 19'],
-            [-364, 'July 1'], // Minimum of the recommended range
+            [-1708, 'October 25'], // At least 4 years to ensure no issue with leap years
         ])('works with value below 1 (%s)', (value, expected) => {
             const output = doyFormatter(value, 'en-CA', true);
             expect(output).toEqual(expected);
@@ -91,7 +91,7 @@ describe('doyFormatter', () => {
         test.each([
             [366, 'July 1'],
             [417, 'August 21'],
-            [730, 'June 30'], // Maximum of the recommended range
+            [1708, 'March 5'], // At least 4 years to ensure no issue with leap years
         ])('works with value above 365 (%s)', (value, expected) => {
         const output = doyFormatter(value, 'en-CA', true);
         expect(output).toEqual(expected);

--- a/apps/src/lib/format.ts
+++ b/apps/src/lib/format.ts
@@ -128,8 +128,7 @@ export const normalizePostData = async (
  * doyFormatter(100, 'en-CA', false, 'numeric'); // 04-10
  * ```
  *
- * @param value - The day of the year (first day is 1, not 0!). Should be in the
- *        range [-364, 730].
+ * @param value - The day of the year (first day is 1, not 0!).
  * @param language - The language code to use for formatting.
  * @param firstDayIsJuly - If true, the first day of the year will be July 1st,
  *        else it will be January 1st.
@@ -143,13 +142,10 @@ export const doyFormatter = (
 	monthFormat: MonthFormat = 'long',
 ) => {
 	const firstMonthOfYear = firstDayIsJuly ? 6 : 0;
-	// To prevent issues with leap years, we choose a year that has as much
-	// room as possible before the next leap year (based on the direction where
-	// we go).
-	const year = value > 0 ? 2017 : 2019;
-	// First day of the year (UTC).
+	// First day of the year (UTC). We choose 2018 because neither 2017, 2018
+	// nor 2019 are leap years.
 	// Reminder: the month's index is 0-based, but the day's index is 1-based.
-	const firstDayOfYear = Date.UTC(year, firstMonthOfYear, 1);
+	const firstDayOfYear = Date.UTC(2018, firstMonthOfYear, 1);
 
 	// Convert the day-of-year value (1 = first day of the year) to a Date object
 	const millisecondsDelta = (value - 1) % 365 * 1000 * 60 * 60 * 24;

--- a/apps/src/lib/format.ts
+++ b/apps/src/lib/format.ts
@@ -115,14 +115,24 @@ export const normalizePostData = async (
 /**
  * Format a day of the year number to its localized date.
  *
+ * The reference year is not a leap year.
+ *
+ * Negative values and values above 365 are supported, but should be limited to
+ * +/- 1 years outside the range [0, 365] (i.e. [-364, 730]) to prevent
+ * unexpected results do to leap years.
+ *
+ * The first day of the year can be set to be either January 1st or July 1st.
+ *
  * @example
  * ```typescript
  * doyFormatter(1, 'en-US'); // January 1
+ * doyFormatter(-23, 'en-US'); // December 8
  * doyFormatter(1, 'fr-CA', true); // 1 juillet
  * doyFormatter(100, 'en-CA', false, 'numeric'); // 04-10
  * ```
  *
- * @param value - The day of the year (first day is 1, not 0!).
+ * @param value - The day of the year (first day is 1, not 0!). Should be in the
+ *        range [-364, 730].
  * @param language - The language code to use for formatting.
  * @param firstDayIsJuly - If true, the first day of the year will be July 1st,
  *        else it will be January 1st.
@@ -136,14 +146,16 @@ export const doyFormatter = (
 	monthFormat: MonthFormat = 'long',
 ) => {
 	const firstMonthOfYear = firstDayIsJuly ? 6 : 0;
-	// First day of the year (UTC). We choose 2018 because neither 2018 nor
-	// 2019 are leap years.
+	// To prevent issues with leap years, we choose a year that has as much
+	// room as possible before the next leap year (based on the direction where
+	// we go).
+	const year = value > 0 ? 2017 : 2019;
+	// First day of the year (UTC).
 	// Reminder: the month's index is 0-based, but the day's index is 1-based.
-	const firstDayOfYear = Date.UTC(2018, firstMonthOfYear, 1);
-	const boundedValue = Math.max(1, Math.min(value, 365));
+	const firstDayOfYear = Date.UTC(year, firstMonthOfYear, 1);
 
 	// Convert the day-of-year value (1 = first day of the year) to a Date object
-	const millisecondsDelta = (boundedValue - 1) * 1000 * 60 * 60 * 24;
+	const millisecondsDelta = (value - 1) * 1000 * 60 * 60 * 24;
 	const date = new Date(firstDayOfYear + millisecondsDelta);
 
 	// Format the date according to the given language

--- a/apps/src/lib/format.ts
+++ b/apps/src/lib/format.ts
@@ -115,11 +115,8 @@ export const normalizePostData = async (
 /**
  * Format a day of the year number to its localized date.
  *
- * The reference year is not a leap year.
- *
- * Negative values and values above 365 are supported, but should be limited to
- * +/- 1 years outside the range [0, 365] (i.e. [-364, 730]) to prevent
- * unexpected results do to leap years.
+ * Zero, negative values, and values above 365 are supported. All calculations
+ * are done on non-leap years.
  *
  * The first day of the year can be set to be either January 1st or July 1st.
  *
@@ -155,7 +152,7 @@ export const doyFormatter = (
 	const firstDayOfYear = Date.UTC(year, firstMonthOfYear, 1);
 
 	// Convert the day-of-year value (1 = first day of the year) to a Date object
-	const millisecondsDelta = (value - 1) * 1000 * 60 * 60 * 24;
+	const millisecondsDelta = (value - 1) % 365 * 1000 * 60 * 60 * 24;
 	const date = new Date(firstDayOfYear + millisecondsDelta);
 
 	// Format the date according to the given language


### PR DESCRIPTION
## Description

Issue: The `dayFormatter` function "clips" values that are outside the range `[1, 365]`. So `dayFormatter(1) === dayFormatter(0)`.

This creates issues when we need to show values that are before `1` or after `365`. For example, in the graph that show axes value outside the range:

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/bd1362d8-7a54-4523-a074-1696653858ec" />

([From this URL](https://uat.climatedata.ca/maps/?var=last_snow_fall&th=last_snowfall&dataset=216&dataOpacity=100&labelOpacity=100&lat=60.40029&lng=-138.40027&zoom=8#))

<img width="300" alt="image" src="https://github.com/user-attachments/assets/d567791a-4389-4ce9-8ef0-7d129b0d2547" />

([From this URL](https://uat.climatedata.ca/maps/?var=first_snow_fall&th=first_snowfall&dataset=216&dataOpacity=100&labelOpacity=100&lat=60.40029&lng=-138.40027&zoom=8#))

### This PR

This PR fixes the issue by allowing the user to use values outside the `[0, 365]` range (the value is transformed to a value in the `[-364, 365]` range using a modulo).

After the fix:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/80aee8a5-690e-4608-aaaa-882402b1f577" />

&nbsp;

<img width="300" alt="image" src="https://github.com/user-attachments/assets/a668dc22-0b50-49f8-b552-96143583bb4f" />


## Related ticket

CLIM-1376