### PR TITLE
CLIM-1322 (4): Popup Title Display Discrepancy When InteractiveRegionOption.GRIDDED_DATA

### DIFF
--- a/apps/src/components/map-container.tsx
+++ b/apps/src/components/map-container.tsx
@@ -60,6 +60,9 @@ interface MapContainerProps {
 	onClick: (e: { latlng: L.LatLng; layer: { properties: unknown } }) => void;
 	selectedLocation: SelectedLocationInfo | null;
 	clearSelectedLocation: () => void;
+	selectGriddedLocation?: (
+		input: { latlng: L.LatLng; title: string },
+	) => void;
 	// @ts-expect-error: L.VectorGrid is a valid type
 	layerRef?: React.MutableRefObject<L.VectorGrid | null>;
 }
@@ -76,6 +79,7 @@ export default function MapContainer({
 	onClick,
 	selectedLocation,
 	clearSelectedLocation,
+	selectGriddedLocation,
 	layerRef,
 }: MapContainerProps): React.ReactElement {
 	const [locationModalContent, setLocationModalContent] = useState<React.ReactNode>(null);
@@ -245,7 +249,11 @@ export default function MapContainer({
 			<ZoomControl />
 
 			{/* Show search control if not a comparison map. */}
-			{ !isComparisonMap && <SearchControl /> }
+			{ !isComparisonMap && (
+				<SearchControl
+					onSelectGriddedLocation={selectGriddedLocation}
+				/>
+			) }
 
 			<LocationModal
 				isOpen={canShowModal}

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -280,13 +280,23 @@ const SearchControl = ({
 					return;
 				}
 				// Check if the coordinates are valid if the location is empty.
-				const latLng = parseLatLon(this._input.value);
+				const latLon = parseLatLon(this._input.value);
 				// If the coordinates are valid, move to that location.
-				if (latLng && !latLng.isPartial) {
-					// Fetch location data
-					const locationByCoords = await fetchLocationByCoords({ lat: latLng.lat, lng: latLng.lon });
-					// Trigger show location.
-					this.showLocation(locationByCoords, locationByCoords.title);
+				if (latLon && !latLon.isPartial) {
+					const latLng = {
+						lat: latLon.lat,
+						lng: latLon.lon,
+					}
+					const locationByCoords = await fetchLocationByCoords(latLng);
+					const locationAtTypedCoords = {
+						...locationByCoords,
+						lat: latLng.lat,
+						lng: latLng.lng,
+					};
+					this.showLocation(
+						locationAtTypedCoords,
+						locationByCoords.title,
+					);
 				}
 				else {
 					// Show error alert.

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -131,9 +131,7 @@ const SearchControl = ({
 			const interactiveRegion = climateVariable?.getInteractiveRegion()
 				?? InteractiveRegionOption.GRIDDED_DATA;
 
-			// UC-Search in GRIDDED_DATA: the autocomplete row already has a
-			// usable title — set the selected location directly. Skip the
-			// synthetic-click reverse-lookup path that the other modes need.
+			// The autocomplete row already has a usable title — set the selected location directly.
 			if (
 				autocompleteItem
 				&& interactiveRegion === InteractiveRegionOption.GRIDDED_DATA
@@ -143,12 +141,13 @@ const SearchControl = ({
 					latlng,
 					title: autocompleteItem.title,
 				});
+				// Skip the synthetic-click reverse-lookup path that the other modes need.
 				return;
 			}
 
 			// UC-LocateMe, UC-RawCoordPaste, and all polygon modes:
 			// fall through to existing behaviour from main.
-			await dispatchMapClick(map, latlng);
+			await dispatchMapClick(map);
 		},
 		[
 			climateVariable,

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -272,6 +272,13 @@ const SearchControl = ({
 				void _; // intentionally ignore to suppress typescript error
 				return `<div>${buildLocationTitle(item)}</div>`;
 			},
+
+			/**
+			 * Search by raw "lat,lon" coordinates or anything else entry point.
+			 *
+			 * The autocomplete-hit path (UC-Search) never reaches here; it lands
+			 * in `moveToLocation` above with a matching row in formattedItemsRef.
+			 */
 			locationNotFound: async function() {
 				// If the list of suggestions is still shown, no error message is shown.
 				// See #86862
@@ -279,21 +286,21 @@ const SearchControl = ({
 					this.showTooltip(this._recordsCache)
 					return;
 				}
-				// Check if the coordinates are valid if the location is empty.
-				const latLon = parseLatLon(this._input.value);
+
+				// parseLatLon is both PARSER and DETECTOR: a non-partial result means
+				// the input was a valid "lat, lon" string.
+				const parsedSearchControlInput = parseLatLon(this._input.value);
 				// If the coordinates are valid, move to that location.
-				if (latLon && !latLon.isPartial) {
-					const latLng = {
-						lat: latLon.lat,
-						lng: latLon.lon,
-					}
+				if (parsedSearchControlInput && !parsedSearchControlInput.isPartial) {
+					const latLng = new L.LatLng(parsedSearchControlInput.lat, parsedSearchControlInput.lon);
 					const locationByCoords = await fetchLocationByCoords(latLng);
 
 					// Bypass leaflet-search's showLocation pipeline for GRIDDED mode so the
-					// marker lands at the typed coordinates rather than the synthetic-click
-					// container-center reprojection. Polygon modes (CENSUS/HEALTH/WATERSHED)
-					// fall through to the existing showLocation path because their popup
-					// title comes from layer.properties.label_* and the small drift is
+					// marker lands at the typed coordinates rather than dispatchMapClick
+					// calculated center (container-center reprojection).
+					// Other `InteractiveRegionOption.` modes (CENSUS/HEALTH/WATERSHED)
+					// fall through because their popup title comes from
+					// `layer.properties.label_*` and the small drift is
 					// benign at polygon scale.
 					const interactiveRegion = climateVariable?.getInteractiveRegion()
 						?? InteractiveRegionOption.GRIDDED_DATA;
@@ -304,19 +311,18 @@ const SearchControl = ({
 					) {
 						map.setView(latLng, SEARCH_DEFAULT_ZOOM);
 						onSelectGriddedLocation({
-							latlng: L.latLng(latLng.lat, latLng.lng),
+							latlng: latLng,
 							title: locationByCoords.title,
 						});
 						return;
 					}
 
-					const locationAtTypedCoords = {
-						...locationByCoords,
-						lat: latLng.lat,
-						lng: latLng.lng,
-					};
 					this.showLocation(
-						locationAtTypedCoords,
+						{
+							...locationByCoords,
+							lat: latLng.lat,
+							lng: latLng.lng,
+						},
 						locationByCoords.title,
 					);
 				}

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -235,7 +235,7 @@ const SearchControl = ({
 					// Fetch location data
 					const locationByCoords = await fetchLocationByCoords({ lat: latLng.lat, lng: latLng.lon });
 					// Trigger show location.
-					this.showLocation(locationByCoords, locationByCoords.geo_id);
+					this.showLocation(locationByCoords, locationByCoords.title);
 				}
 				else {
 					// Show error alert.

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -8,6 +8,7 @@ import {
 	useCallback,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from 'react';
 import { __ } from '@/context/locale-provider';
@@ -20,6 +21,7 @@ import 'leaflet-search/dist/leaflet-search.min.css';
 import 'leaflet-search';
 import mapPinIcon from '@/assets/map-pin.svg';
 
+import { useClimateVariable } from '@/hooks/use-climate-variable';
 import { cn, parseLatLon } from '@/lib/utils';
 import { dispatchMapClick } from '@/lib/dispatch-map-click';
 import { fetchLocationByCoords } from '@/services/services';
@@ -27,6 +29,7 @@ import {
 	type SearchControlLocationItem,
 	type SearchControlResponse,
 } from '@/types/types';
+import { InteractiveRegionOption } from '@/types/climate-variable-interface';
 import {
 	LOCATION_SEARCH_ENDPOINT,
 	SEARCH_DEFAULT_ZOOM,
@@ -57,6 +60,14 @@ function convertSearchLatLng(inputLatLng: SearchLatLng): L.LatLng {
  */
 export interface SearchControlProps {
 	className?: string;
+	/**
+	 * Set selected location directly from an autocomplete pick when the
+	 * climate variable's interactive region is GRIDDED_DATA. Bypasses the
+	 * synthetic-click + reverse-coords-lookup path.
+	 */
+	onSelectGriddedLocation?: (
+		input: { latlng: L.LatLng; title: string },
+	) => void;
 }
 
 /**
@@ -71,7 +82,16 @@ export interface SearchControlProps {
  */
 const SearchControl = ({
 	className,
+	onSelectGriddedLocation,
 }: SearchControlProps): ReactElement => {
+	const { climateVariable } = useClimateVariable();
+	// Captured at the point formatData() builds entries, keyed by the same
+	// title string leaflet-search later passes back to moveToLocation().
+	// A closure-scoped Map keeps lookup local to the search lifecycle
+	// and avoids any cross-render leakage.
+	const formattedItemsRef = useRef<Map<string, SearchControlLocationItem>>(
+		new Map(),
+	);
 	const [isGeolocationEnabled, setIsGeolocationEnabled] =
 		useState<boolean>(false);
 	const [isTracking, setIsTracking] = useState<boolean>(false);
@@ -95,7 +115,10 @@ const SearchControl = ({
 	const map = useMap();
 
 	const handleLocationChange = useCallback(
-		async (inputLatlng: SearchLatLng) => {
+		async (
+			inputLatlng: SearchLatLng,
+			autocompleteItem?: { item: SearchControlLocationItem; title: string },
+		) => {
 			const latlng = convertSearchLatLng(inputLatlng);
 			// clear all existing markers from the map
 			map.eachLayer(layer => {
@@ -104,10 +127,33 @@ const SearchControl = ({
 				}
 			});
 			map.setView(latlng, SEARCH_DEFAULT_ZOOM);
+
+			const interactiveRegion = climateVariable?.getInteractiveRegion()
+				?? InteractiveRegionOption.GRIDDED_DATA;
+
+			// UC-Search in GRIDDED_DATA: the autocomplete row already has a
+			// usable title — set the selected location directly. Skip the
+			// synthetic-click reverse-lookup path that the other modes need.
+			if (
+				autocompleteItem
+				&& interactiveRegion === InteractiveRegionOption.GRIDDED_DATA
+				&& onSelectGriddedLocation
+			) {
+				onSelectGriddedLocation({
+					latlng,
+					title: autocompleteItem.title,
+				});
+				return;
+			}
+
+			// UC-LocateMe, UC-RawCoordPaste, and all polygon modes:
+			// fall through to existing behaviour from main.
 			await dispatchMapClick(map, latlng);
 		},
 		[
+			climateVariable,
 			map,
+			onSelectGriddedLocation,
 		],
 	);
 
@@ -205,6 +251,11 @@ const SearchControl = ({
 					SearchControlLocationItem & { loc: number[]; lng: string; }
 				> = {};
 
+				// Reset and rebuild the title→item index for the current
+				// suggestion set, so moveToLocation can look the row up by
+				// title without round-tripping through the server.
+				formattedItemsRef.current.clear();
+
 				response.items.forEach((item: SearchControlLocationItem) => {
 					const title = buildLocationTitle(item);
 					const loc = [parseFloat(item.lat), parseFloat(item.lon)];
@@ -213,6 +264,7 @@ const SearchControl = ({
 						lng: item.lon,
 						loc,
 					};
+					formattedItemsRef.current.set(title, item);
 				});
 
 				return formattedData;
@@ -250,8 +302,18 @@ const SearchControl = ({
 					popupAnchor: [0, -41], // Popup position relative to the icon
 				}),
 			}),
-			moveToLocation: (latlng: SearchLatLng) => {
-				handleLocationChange(latlng);
+			moveToLocation: (latlng: SearchLatLng, title: string) => {
+				// leaflet-search invokes this with (latlng, title, map);
+				// `title` is the same key formatData() used in formattedData,
+				// so we can recover the original autocomplete row from it.
+				const item = formattedItemsRef.current.get(title);
+				if (item) {
+					handleLocationChange(latlng, { item, title });
+				} else {
+					// No matching row (e.g. raw lat/lon paste branch from
+					// locationNotFound) — fall through to existing behaviour.
+					handleLocationChange(latlng);
+				}
 			},
 		});
 

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -288,6 +288,28 @@ const SearchControl = ({
 						lng: latLon.lon,
 					}
 					const locationByCoords = await fetchLocationByCoords(latLng);
+
+					// Bypass leaflet-search's showLocation pipeline for GRIDDED mode so the
+					// marker lands at the typed coordinates rather than the synthetic-click
+					// container-center reprojection. Polygon modes (CENSUS/HEALTH/WATERSHED)
+					// fall through to the existing showLocation path because their popup
+					// title comes from layer.properties.label_* and the small drift is
+					// benign at polygon scale.
+					const interactiveRegion = climateVariable?.getInteractiveRegion()
+						?? InteractiveRegionOption.GRIDDED_DATA;
+
+					if (
+						interactiveRegion === InteractiveRegionOption.GRIDDED_DATA
+						&& onSelectGriddedLocation
+					) {
+						map.setView(latLng, SEARCH_DEFAULT_ZOOM);
+						onSelectGriddedLocation({
+							latlng: L.latLng(latLng.lat, latLng.lng),
+							title: locationByCoords.title,
+						});
+						return;
+					}
+
 					const locationAtTypedCoords = {
 						...locationByCoords,
 						lat: latLng.lat,

--- a/apps/src/components/map-layers/search-control.tsx
+++ b/apps/src/components/map-layers/search-control.tsx
@@ -305,10 +305,16 @@ const SearchControl = ({
 			moveToLocation: (latlng: SearchLatLng, title: string) => {
 				// leaflet-search invokes this with (latlng, title, map);
 				// `title` is the same key formatData() used in formattedData,
-				// so we can recover the original autocomplete row from it.
+				// (the verbose buildLocationTitle output, kept for the
+				// dropdown display), so we can recover the original
+				// autocomplete row from it.
 				const item = formattedItemsRef.current.get(title);
 				if (item) {
-					handleLocationChange(latlng, { item, title });
+					// UC-Search popup title uses the short server-resolved
+					// shape ("Montréal, QC"), matching cdc_get_location_by_coords,
+					// not the verbose dropdown display.
+					const popupTitle = `${item.text}, ${item.province_short}`;
+					handleLocationChange(latlng, { item, title: popupTitle });
 				} else {
 					// No matching row (e.g. raw lat/lon paste branch from
 					// locationNotFound) — fall through to existing behaviour.

--- a/apps/src/components/map.tsx
+++ b/apps/src/components/map.tsx
@@ -33,7 +33,8 @@ export default function Map(): React.ReactElement {
 		handleOver,
 		handleOut,
 		handleClick,
-		handleClearSelectedLocation
+		handleClearSelectedLocation,
+		selectGriddedLocation,
 	} = useMapInteractions({
 		primaryLayerRef,
 		comparisonLayerRef,
@@ -95,6 +96,7 @@ export default function Map(): React.ReactElement {
 				onClick={handleClick}
 				selectedLocation={selectedLocation}
 				clearSelectedLocation={handleClearSelectedLocation}
+				selectGriddedLocation={selectGriddedLocation}
 				layerRef={primaryLayerRef}
 			/>
 			{showComparisonMap && (

--- a/apps/src/components/sidebar-footer-links/recent-locations.tsx
+++ b/apps/src/components/sidebar-footer-links/recent-locations.tsx
@@ -62,7 +62,7 @@ const RecentLocationsPanel: React.FC = () => {
 
 	const moveToLocation = async (location: MapLocation) => {
 		map.setView(location, SEARCH_DEFAULT_ZOOM);
-		await dispatchMapClick(map, location);
+		await dispatchMapClick(map);
 	};
 
 	return (

--- a/apps/src/hooks/use-map-interactions.tsx
+++ b/apps/src/hooks/use-map-interactions.tsx
@@ -95,17 +95,24 @@ export function useMapInteractions({ primaryLayerRef, comparisonLayerRef }: UseM
       ...latlng,
     }));
 
-    setSelectedLocation({ featureId: featureId ?? 0, title: locationTitle, latlng });
-  }, [clearMarkers, addMarker, dispatch, climateVariable, locale]);
+    setSelectedLocation({
+			featureId: featureId ?? 0,
+			latlng,
+			title: locationTitle,
+		});
+  }, [
+		addMarker,
+		clearMarkers,
+		climateVariable,
+		dispatch,
+		locale,
+	]);
 
-  const handleClearSelectedLocation = useCallback(() => {
-    setSelectedLocation(null);
-    clearMarkers();
-  }, [clearMarkers]);
-
-  // Used by the search control's autocomplete branch in GRIDDED_DATA mode:
-  // the autocomplete row already carries a usable display title, so we set
-  // the selected location directly without a reverse-coords lookup.
+  /**
+	 * Used by the `search-control.tsx`'s autocomplete branch in GRIDDED_DATA mode:
+	 * the autocomplete row already carries a usable display title, so we set
+	 * the selected location directly without a reverse-coords lookup.
+	 */
   const selectGriddedLocation = useCallback((
     { latlng, title }: { latlng: L.LatLng; title: string },
   ) => {
@@ -119,8 +126,21 @@ export function useMapInteractions({ primaryLayerRef, comparisonLayerRef }: UseM
       lng: latlng.lng,
     }));
 
-    setSelectedLocation({ featureId: 0, title, latlng });
-  }, [clearMarkers, addMarker, dispatch]);
+    setSelectedLocation({
+			featureId: 0,
+			latlng,
+			title,
+		});
+  }, [
+		addMarker,
+		clearMarkers,
+		dispatch,
+	]);
+
+  const handleClearSelectedLocation = useCallback(() => {
+    setSelectedLocation(null);
+    clearMarkers();
+  }, [clearMarkers]);
 
   // Effect to handle location updates when climate variables change
   useEffect(() => {

--- a/apps/src/hooks/use-map-interactions.tsx
+++ b/apps/src/hooks/use-map-interactions.tsx
@@ -103,6 +103,25 @@ export function useMapInteractions({ primaryLayerRef, comparisonLayerRef }: UseM
     clearMarkers();
   }, [clearMarkers]);
 
+  // Used by the search control's autocomplete branch in GRIDDED_DATA mode:
+  // the autocomplete row already carries a usable display title, so we set
+  // the selected location directly without a reverse-coords lookup.
+  const selectGriddedLocation = useCallback((
+    { latlng, title }: { latlng: L.LatLng; title: string },
+  ) => {
+    clearMarkers();
+    addMarker(latlng, title);
+
+    dispatch(addRecentLocation({
+      id: `${latlng.lat}|${latlng.lng}`,
+      title,
+      lat: latlng.lat,
+      lng: latlng.lng,
+    }));
+
+    setSelectedLocation({ featureId: 0, title, latlng });
+  }, [clearMarkers, addMarker, dispatch]);
+
   // Effect to handle location updates when climate variables change
   useEffect(() => {
     const interactiveRegion = climateVariable?.getInteractiveRegion() ?? null;
@@ -140,5 +159,6 @@ export function useMapInteractions({ primaryLayerRef, comparisonLayerRef }: UseM
     handleOut,
     handleClick,
     handleClearSelectedLocation,
+    selectGriddedLocation,
   };
 }

--- a/apps/src/lib/dispatch-map-click.ts
+++ b/apps/src/lib/dispatch-map-click.ts
@@ -4,20 +4,13 @@ import L from 'leaflet';
  * Dispatches a real DOM PointerEvent on the VectorGrid canvas tile at the
  * map container center after the view settles.
  *
- * `pointer-events: none` on Leaflet's pane wrapper divs causes
- * `document.elementFromPoint` to return the outermost container — canvas
- * tiles are queried via `gridPane.querySelectorAll('canvas')` and filtered
- * by bounding rect instead.
- *
  * `Promise.race` with a 1,000 ms timeout guards the case where `setView`
  * fires `moveend` synchronously (short pan, no animation) before the
  * listener is attached.
  */
 export const dispatchMapClick = async (
 	map: L.Map,
-	latlng: { lat: number; lng: number },
 ): Promise<void> => {
-	void latlng;
 	await Promise.race([
 		new Promise<void>((resolve) => map.once('moveend', () => resolve())),
 		new Promise<void>((resolve) => setTimeout(resolve, 1_000)),
@@ -31,6 +24,11 @@ export const dispatchMapClick = async (
 	if (!gridPane) {
 		return;
 	}
+	// `pointer-events: none` on Leaflet's pane wrapper divs causes
+	// `document.elementFromPoint` to return the outermost container — the
+	// canvas tiles themselves are not hit-testable through that API. We
+	// enumerate the grid pane's canvases and filter by their bounding rect
+	// to find the one under (clientX, clientY) instead.
 	const canvases = Array.from(gridPane.querySelectorAll('canvas'));
 	const target = canvases.find((canvas) => {
 		const r = canvas.getBoundingClientRect();

--- a/apps/src/services/services.ts
+++ b/apps/src/services/services.ts
@@ -455,6 +455,8 @@ export const fetchPostsData = async (
 /**
  * Fetches location data from the API
  *
+ * Call to WordPress wp-api endpoint `/wp-json/cdc/v2/get_location_by_coords`
+ *
  * @param latlng Latitude and Longitude of the location
  * @param fetchOptions Any other options to pass to fetch (ex: `signal`)
  */

--- a/apps/src/types/types.ts
+++ b/apps/src/types/types.ts
@@ -519,6 +519,12 @@ export interface SearchControlLocationItem {
 	term: string;
 	location: string;
 	province: string;
+	/**
+	 * 2-letter province code derived server-side via short_province().
+	 * @example 'QC', 'NS', 'BC' — pairs with `text` to form the popup
+	 * title shape used by cdc_get_location_by_coords ("Montréal, QC").
+	 */
+	province_short: string;
 	lat: string;
 	lon: string;
 }

--- a/fw-child/resources/functions/rest.php
+++ b/fw-child/resources/functions/rest.php
@@ -589,6 +589,11 @@ function cdc_location_search() {
 		$response['items'] = array();
 
 		// finish getting rows from the main query
+		// preserve existing `{id, text, term, location, province, lat, lon} response shape;
+		// `province_short` is additive, derived via the same `short_province()`
+		// helper used by cdc_get_location_by_coords/_by_id so the client can
+		// render the same "geo_name, XX" shape as those endpoints without
+		// duplicating the province-name → 2-letter mapping in JS.
 		while ( $row = mysqli_fetch_row ( $main_query ) ) {
 			$row = array (
 				"id" => $row[0],
@@ -596,6 +601,7 @@ function cdc_location_search() {
 				"term" => $row[2],
 				"location" => $row[3],
 				"province" => $row[4],
+				"province_short" => short_province ( $row[4] ),
 				"lat" => $row[5],
 				"lon" => $row[6]
 			);

--- a/fw-child/resources/functions/rest.php
+++ b/fw-child/resources/functions/rest.php
@@ -367,7 +367,7 @@ function cdc_get_location_by_coords () {
 				"geo_name",
 				"gen_term" . $term_append . " as generic_term",
 				"location",
-				"province" . $term_append,
+				"province" . $term_append . " as province",
 				"lat",
 				"lon"
 			);


### PR DESCRIPTION
**Popup Title Display Discrepancy When InteractiveRegionOption.GRIDDED_DATA**

## Summary

Pass 4 minimal hot-fix synthesis for CLIM-1322. Cherry-picks the load-bearing fixes from Passes 2 and 3, adds two native commits (Atoms 15 & 16) to close **DoD-1** (name parity EN/FR for UC-Search) and **DoD-2** (raw lat/lng pin precision for UC-RawCoordPaste) within `InteractiveRegionOption.GRIDDED_DATA`. Polygon modes (CENSUS / HEALTH / WATERSHED) untouched. No SQL filter rewrite — that work remains parked on `CLIM-1322_3_Popup-Title-Name-Resolution` for a future ticket.

Branched from `origin/main` at `2044c88d`. Diff vs main: 9 files, ~140 added / ~21 removed.

## Use cases addressed (GRIDDED_DATA)

| Use case | What changes in this PR |
|---|---|
| **UC-Search** (autocomplete pick) | Popup title built from the autocomplete row directly: `${item.text}, ${item.province_short}` (e.g. `"Montréal, QC"`). One API call: `/wp-json/cdc/v2/location_search?q=…`. No second `/get_location_by_coords` round-trip. Closes DoD-1. |
| **UC-MapClick** | Untouched — real DOM clicks; existing `handleClick` flow. |
| **UC-RawCoordPaste** (typed `lat, lng`) | Marker now lands at the typed coord exactly — bypasses leaflet-search's `showLocation → moveToLocation → handleLocationChange → dispatchMapClick → containerPointToLatLng` chain that previously produced ~80m drift. Polygon modes preserve existing behavior (drift benign at polygon scale; title from `layer.properties.label_*` regardless). Closes DoD-2. |

## Atoms

| Atom | Origin | What it does |
|---|---|---|
| **Atom 1** | cherry-picked from #682 | Server: `cdc_get_location_by_coords` SELECT aliases `province_fr` as `province`. Eliminates FR `Undefined array key "province"` warning and the trailing-comma title (`"Sainte-Adèle, "` → `"Sainte-Adèle, QC"`). |
| **Atom 3** | cherry-picked from #682 | Client: `locationNotFound` passes the readable `.title` to `showLocation`'s second arg instead of the opaque 5-char `.geo_id`. |
| **Atom 14** | cherry-picked from `CLIM-1322_3_…` | Introduces `selectGriddedLocation({latlng, title})` exported from `useMapInteractions`; prop-chained as `onSelectGriddedLocation` through `Map → MapContainer → SearchControl`. UC-Search GRIDDED invokes it directly with the autocomplete row's data — no synthetic-click round-trip. |
| **Atom 12** | cherry-picked from `CLIM-1322_3_…` | Server: `cdc_location_search` additively returns `province_short` via the same `short_province()` helper used by `cdc_get_location_by_coords`. Client: `SearchControlLocationItem.province_short` typed; UC-Search popup title becomes the short-form `${item.text}, ${item.province_short}`. |
| **Atom 15** | native | `dispatchMapClick` drops its `latlng` parameter — it was always discarded (`void latlng;`). Clarifies design intent: the function is solely about dispatching a real-browser-equivalent `PointerEvent('click')` at the map container's geometric center after `setView` settles. Updates two call sites (`search-control.tsx`, `recent-locations.tsx`). |
| **Atom 16** | native | UC-RawCoordPaste GRIDDED early-return in `locationNotFound`: branches on `interactiveRegion === GRIDDED_DATA && onSelectGriddedLocation` to call `setView` + `onSelectGriddedLocation({latlng: typed, title: server-resolved})` + return. Bypasses leaflet-search's `showLocation` chain. Polygon-mode `else` branch preserves the existing `showLocation` + spread-override path. |

## Definition of Done

- **DoD-1 — name parity EN/FR for UC-Search at the same row:** achieved structurally. Same autocomplete row → same `province_short` → same short-form popup title regardless of UI language. Example: Laval row `EGYIC` → `"Laval, QC"` whether the user typed in EN or FR autocomplete.
- **DoD-2 — raw lat/lng pin precision:** achieved empirically. Atom 16's early-return passes the typed `latLng` directly to `selectGriddedLocation`, bypassing the synthetic-click reprojection chain that produced ~80m drift via `containerPointToLatLng` on container-center pixel coords.

## Out of scope (parked for follow-up)

- **SQL filter rewrite / `gen_term` tier preferences** — full design and probe-verification on `CLIM-1322_3_Popup-Title-Name-Resolution` (not merged). Would address T28 (Park-class defects: McMasterville → "Parc Ensoleillé", Bedford → "Parc des Bouts-de-Choux") for UC-MapClick and UC-LocateMe. UC-Search T28 dissolves structurally in this PR via Atom 14 because the autocomplete row never round-trips through `cdc_get_location_by_coords`.
- **`dispatchMapClick → moveAndPointAt` rename + per-map WeakMap precise-latlng channel** — Iteration 2's Atoms 6/8/9. Out of scope here because UC-Search bypasses the synthetic-click pipeline (no consumer in scope) and UC-RawCoordPaste GRIDDED takes the early-return path in Atom 16. Logically a single follow-up unit if a future ticket needs precise pin placement under the synthetic-click path.
- **`MapFeatureProperties` typing migration** — parked on a separate local branch `stashed/MapFeatureProperties` (single pure-typing commit). Pure refactor; pick up in a typing-only PR.

## Verification

- [x] `./dev.sh typecheck-apps` clean.
- [x] `./dev.sh lint-apps` clean on touched files (one pre-existing warning on an untouched line in `Map`'s `useEffect` deps).
- [x] API probes against local development `dev-en` and `dev-fr` for the 16-anchor reference table (Vancouver / Montréal / Halifax / Sainte-Adèle / Toronto / Edmonton / Calgary / Victoria / Ottawa / Québec / Charlottetown / St. John's / Saskatoon / Banff / Bedford / McMasterville) confirm short-form popup titles for UC-Search GRIDDED.
- [x] Check with raw `lat,lon` raw coord tuples (UC-RawCoordPaste) at five precision levels (2 to 6 decimal places) confirmed marker matches typed coord after Atom16 — the empirical signature that previously identified the ~80m drift (identical post-`setView` viewport-center across coords differing only in low-order decimals) is gone.

## Related

- **Ticket:** [CLIM-1322](https://ccdpwiki.atlassian.net/browse/CLIM-1322)

- **Parked branches preserved as research:** 
  - (Pass 2; #682)
  - `CLIM-1322_3_Popup-Title-Name-Resolution`
  -  `stashed/MapFeatureProperties`


**Supersedes earlier Passes:**
- **Pass 1** #674 — Illustrative of a solution path.
- **Pass 2** full SQL filter rewrite, kept as parked research
  - Branch: `CLIM-1322_2_Popup-Title-Name-Resolution`
  - #682
 
- **Pass 3** #684 — continuation of Pass 2 but introduced `ORDER BY` ranking and this change would solve other problems identified such as clicking on the map to very close-by location (pixel on the screen at a high zoom level) with wildly different popup titles


[CLIM-1322]: https://ccdpwiki.atlassian.net/browse/CLIM-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ