### PR TITLE
CLIM-1395: Fix: Download: AHCCD blocked at step 3

### DIFF
--- a/apps/src/components/download/step-variable-options.tsx
+++ b/apps/src/components/download/step-variable-options.tsx
@@ -34,7 +34,8 @@ const validateS2DVariable = (
 const validateRegularVariable = (
 	climateVariable: ClimateVariableInterface,
 ): unknown[] => {
-	const version = climateVariable.getVersion();
+	// The selected version or `true` if the variable doesn't have a version concept
+	const version = climateVariable.getVersion() ?? true;
 	const analysisFields = climateVariable.getAnalysisFields() ?? [];
 	const values = climateVariable.getAnalysisFieldValues() ?? {};
 	const thresholdPossibleValues = climateVariable.getThresholds() ?? [];

--- a/apps/src/components/download/step-variable-options.tsx
+++ b/apps/src/components/download/step-variable-options.tsx
@@ -34,8 +34,8 @@ const validateS2DVariable = (
 const validateRegularVariable = (
 	climateVariable: ClimateVariableInterface,
 ): unknown[] => {
-	// The selected version or `true` if the variable doesn't have a version concept
-	const version = climateVariable.getVersion() ?? true;
+	const version = climateVariable.getVersion();
+	const hasVersions = climateVariable.getVersions().length > 0;
 	const analysisFields = climateVariable.getAnalysisFields() ?? [];
 	const values = climateVariable.getAnalysisFieldValues() ?? {};
 	const thresholdPossibleValues = climateVariable.getThresholds() ?? [];
@@ -45,7 +45,7 @@ const validateRegularVariable = (
 	// We cannot have both analysis fields and a threshold field
 	const hasThresholdField = !hasAnalysisFields && thresholdPossibleValues.length > 0;
 
-	const versionIsValid = !!version;
+	const versionIsValid = !hasVersions || !!version;
 	const analysisFieldsAreValid = analysisFields
 		.filter(f => f.required !== false)
 		.map(f => {


### PR DESCRIPTION
## Description

Issue: in Download, when selecting a "AHCCD" variable, the user cannot go pass the step 3 because the "next step" button is disabled.

The reason is because the code validates that a version has been selected, but the AHCCD variables don't have versions.

## Related ticket

CLIM-1395