### PR TITLE
CLIM-1390: S2D legend: round quantities when showing the scale

### DIFF
--- a/apps/src/lib/multi-band-legend.test.ts
+++ b/apps/src/lib/multi-band-legend.test.ts
@@ -191,6 +191,16 @@ describe('multi-band-legend', () => {
 					expect(row.colors).not.toContain('#FFFFFF');
 				});
 			});
+
+			it('transforms floating percentages to integer scale (floor rounding)', () => {
+				const input = createFixture(3);
+				// We add a fraction to each quantity
+				input.quantities = input.quantities.map((quantity, index) => quantity + (index % 10) * 0.1);
+
+				const result = transformColorMapToMultiBandLegend(input);
+
+				expect(result.scale).toEqual([40, 50, 60, 70, 80, 90, 100]);
+			});
 		});
 
 		describe('error cases', () => {

--- a/apps/src/lib/multi-band-legend.ts
+++ b/apps/src/lib/multi-band-legend.ts
@@ -297,10 +297,11 @@ const validateQuantityFormat = (quantities: number[]): void => {
 export const transformColorMapToMultiBandLegend = (
 	colorMap: ColourQuantitiesMap,
 ): MultiBandLegend => {
-	const {
-		quantities = [],
-		colours = [],
-	} = colorMap;
+	const colours = colorMap.colours;
+	// The GeoServer layer style may contain floating point quantities, but only
+	// integer percentages must be displayed in the legend. So we round
+	// quantities.
+	const quantities = colorMap.quantities.map(Math.floor);
 	// Validate quantity format FIRST (before any string operations)
 	validateQuantityFormat(quantities);
 	// Validate scale consistency across groups


### PR DESCRIPTION
## Description

The GeoServer fix for CLIM-1390 (S2D zones with values 100% showing white) introduces floating values in the quantities (i.e. `100.1` instead of `100`).

But we don't want to show floating values in the legend.

This PR ensures rounded values are shown in the legend.

A test is added.

## Related ticket

CLIM-1390