### PR TITLE
CLIM-1367 (2): S2D ProgressBar rounding to be consistent

### DIFF
--- a/apps/src/components/map-layers/s2d-location-modal-forecast-summary.tsx
+++ b/apps/src/components/map-layers/s2d-location-modal-forecast-summary.tsx
@@ -13,7 +13,7 @@ import S2DReleaseDate from '@/components/s2d-release-date';
 
 import { buildForecastCategories } from '@/components/map-layers/s2d-build-forecast-categories';
 
-import { type ProgressBarProps } from '@/components/ui/progress-bar';
+import { type ProgressBarProps } from '@/types/progress-bar';
 
 import {
 	ModalSummaryPopover,
@@ -29,6 +29,7 @@ import {
 import {
 	extractSkillLevelData,
 	generatePeriodRangeLabel,
+	normalizeProbabilitiesBarChartPercent,
 	type LocationS2DData,
 } from '@/lib/s2d';
 import {
@@ -129,7 +130,7 @@ const LineTheHistoricalMedian = (
 	if (rule) {
 		const allPercent = progressBars.map(({ percent }) => percent);
 		const eachPercentLessThan = allPercent.map(
-			(percent) => percent < rule.threshold
+			(percent) => normalizeProbabilitiesBarChartPercent({ percent }) < rule.threshold
 		);
 		const forecastHasNoClearOutcome = eachPercentLessThan.every(
 			(isLessThan) => isLessThan === true

--- a/apps/src/components/map-layers/s2d-variable-values.tsx
+++ b/apps/src/components/map-layers/s2d-variable-values.tsx
@@ -14,6 +14,7 @@ import { cn, findCeilingIndex, utc } from '@/lib/utils';
 import {
 	extractSkillLevelData,
 	generatePeriodRangeLabel,
+	normalizeProbabilitiesBarChartPercent,
 	type LocationS2DData,
 } from '@/lib/s2d';
 import { ColourMap } from '@/types/types';
@@ -29,9 +30,11 @@ import {
 import { buildForecastCategories } from '@/components/map-layers/s2d-build-forecast-categories';
 import S2DLocationModalForecastSummary from '@/components/map-layers/s2d-location-modal-forecast-summary';
 
+import ProgressBar from '@/components/ui/progress-bar';
+import type { ProgressBarProps } from '@/types/progress-bar';
+
 import TooltipWidget from '@/components/ui/tooltip-widget';
 import StarRating from '@/components/ui/star-rating';
-import ProgressBar, { ProgressBarProps } from '@/components/ui/progress-bar';
 import S2DReleaseDate from '@/components/s2d-release-date';
 import { Spinner } from '@/components/ui/spinner';
 
@@ -186,7 +189,7 @@ export const getProbabilityColour = (
 ): `#${string}` => {
 	const colours = colorMap.colours as `#${string}`[];
 	const defaultColor = '#909090';
-	let percentageForQuery = Math.round(percentage);
+	let percentageForQuery = normalizeProbabilitiesBarChartPercent({ percent: percentage });
 
 	/**
 	 * For values falling exactly on the limit between two colors, we always
@@ -833,7 +836,7 @@ const ProbabilitiesPart = (
 					<li key={idx} className="mt-2 ml-4">
 						{sprintf(
 							__('%d%% probability of being %s (%s)'),
-							Math.round(bar.percent),
+							normalizeProbabilitiesBarChartPercent(bar),
 							forecastCategories[idx].term.toLowerCase(),
 							bar.labelTooltipCutoff,
 						)}

--- a/apps/src/components/map-layers/s2d-variable-values.tsx
+++ b/apps/src/components/map-layers/s2d-variable-values.tsx
@@ -31,7 +31,10 @@ import { buildForecastCategories } from '@/components/map-layers/s2d-build-forec
 import S2DLocationModalForecastSummary from '@/components/map-layers/s2d-location-modal-forecast-summary';
 
 import ProgressBar from '@/components/ui/progress-bar';
-import type { ProgressBarProps } from '@/types/progress-bar';
+import type {
+	HexColor,
+	ProgressBarProps,
+} from '@/types/progress-bar';
 
 import TooltipWidget from '@/components/ui/tooltip-widget';
 import StarRating from '@/components/ui/star-rating';
@@ -186,9 +189,9 @@ export const getProbabilityColour = (
 	outcome: number,
 	percentage: number,
 	colorMap: ColourMap
-): `#${string}` => {
-	const colours = colorMap.colours as `#${string}`[];
-	const defaultColor = '#909090';
+): HexColor => {
+	const colours = colorMap.colours as HexColor[];
+	const defaultColor: HexColor = '#909090';
 	let percentageForQuery = normalizeProbabilitiesBarChartPercent({ percent: percentage });
 
 	/**

--- a/apps/src/components/ui/progress-bar.tsx
+++ b/apps/src/components/ui/progress-bar.tsx
@@ -3,29 +3,12 @@ import { __ } from '@/context/locale-provider';
 import { sprintf } from '@wordpress/i18n';
 import { cn } from '@/lib/utils';
 import { bestContrastingColor } from '@/lib/colors';
-
-export type HexColor = `#${string}`;
-
-export interface ProgressBarProps {
-	/**
-	 * Text to use on top of the progress bar.
-	 */
-	label: string;
-	/**
-	 * Compact cutoff form for the TooltipWidget text,
-	 * e.g. "> 3.5 °C", "1.8 to 3.5 °C", "< 1.0 mm/day".
-	 */
-	labelTooltipCutoff: string;
-	/**
-	 * The width as a percent the bar with background color
-	 * (using fillColor) will take up. A number between 0 and 100.
-	 */
-	percent: number;
-	/**
-	 * Color code to use for the bar
-	 */
-	fillHexCode: HexColor;
-}
+import {
+	type ProgressBarProps,
+} from '@/types/progress-bar';
+import {
+	normalizeProbabilitiesBarChartPercent,
+} from '@/lib/s2d';
 
 /**
  * Progress Bar to illustrate a percent value.
@@ -38,7 +21,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
 	percent,
 	fillHexCode,
 }) => {
-	const roundedPercent = Math.round(percent);
+	const roundedPercent = normalizeProbabilitiesBarChartPercent({percent});
 	const screenReaderOnly = sprintf(__('Horizontal bar at %s%% filled'), roundedPercent);
 	const textLightColor = 'text-white';
 	const textDarkColor = 'text-black';

--- a/apps/src/lib/s2d.ts
+++ b/apps/src/lib/s2d.ts
@@ -8,6 +8,9 @@ import {
 	FrequencyTypes,
 	S2DFrequencyType,
 } from '@/types/climate-variable-interface';
+import type {
+	ProgressBarProps,
+} from '@/types/progress-bar';
 import { formatUTCDate, utc } from '@/lib/utils';
 import { formatIntlDate } from '@/lib/format';
 import { __ } from '@/context/locale-provider';
@@ -452,4 +455,17 @@ export const generatePeriodRangeLabel = (
 	const periodEndLabel = formatIntlDate(periodEnd, locale, { month: 'long' });
 
 	return sprintf(__('%s to %s'), periodStartLabel, periodEndLabel);
+};
+
+/**
+ * The way we represent the percent value and cutoff whether its value is one of the probabilities defined by the cutoffs.
+ * The method of trimming decimal values to determine if the value is part of the cutoff.
+ *
+ * @see {@link LocationS2DData} for the cutoffs and probabilities values.
+ * @see {@link getProbabilityColour} for how the normalized percent value is used to determine the colour of the probability bar.
+ */
+export const normalizeProbabilitiesBarChartPercent = (
+	input: Pick<ProgressBarProps, 'percent'>,
+): number => {
+	return Math.round(input.percent);
 };

--- a/apps/src/types/progress-bar.ts
+++ b/apps/src/types/progress-bar.ts
@@ -1,0 +1,28 @@
+
+/**
+ * String literal type for hex color codes, e.g. "#FFFFFF".
+ */
+export type HexColor = `#${string}`;
+
+export interface ProgressBarProps {
+	/**
+	 * Text to use on top of the progress bar.
+	 */
+	label: string;
+	/**
+	 * Compact cutoff form for the TooltipWidget text,
+	 * e.g. "> 3.5 °C", "1.8 to 3.5 °C", "< 1.0 mm/day".
+	 */
+	labelTooltipCutoff: string;
+	/**
+	 * The width as a percent the bar with background color
+	 * (using fillColor) will take up. A number between 0 and 100.
+	 */
+	percent: number;
+	/**
+	 * Color code to use for the bar
+	 * @see {@link HexColor}
+	 */
+	fillHexCode: HexColor;
+}
+


### PR DESCRIPTION
## Description

The rounding of value to consider if a probability is within or outside of range has to be the same.

## Screenshots

### Report

The fact that we are at a percent that shows rounded to a cutoff (here being `40%`), and is writing that it isn't is confusing.

|  |  |
|--|--|
| <img width="747" height="962" alt="CLIM-1367_Pre-2-Feedback_01" src="https://github.com/user-attachments/assets/9150fb4a-d0ee-4799-be61-af85cdc2ca5a" /> | <img width="834" height="610" alt="CLIM-1367_Pre-2-Feedback_02" src="https://github.com/user-attachments/assets/be3dc408-42af-4d7b-810a-30c973a265ea" /> |


## Related ticket

- #686 
