### PR TITLE
CLIM-1339: Download processing finch error

### DIFF
--- a/apps/src/components/download/steps.tsx
+++ b/apps/src/components/download/steps.tsx
@@ -379,8 +379,9 @@ const Steps: React.FC = () => {
 						}
 					}
 					/**
-					 * outputName might look like, we have to escape paths:
+					 * output_name might contain a slash that then gets taken as a directory separator that we have to escape:
 					 * - "tx_tn_days_above_health_North Shore/Coast Garibaldi Health Service Delivery Area"
+					 * Names like the following has been tested to not cause issues:
 					 * - "tx_days_above_health_Tłı̨chǫ Community Services Agen"
 					 */
 					outputName = outputName

--- a/apps/src/components/download/steps.tsx
+++ b/apps/src/components/download/steps.tsx
@@ -234,9 +234,6 @@ const Steps: React.FC = () => {
 				let latList = '';
 				let lonList = '';
 
-
-				console.log('RBx 0', { interactiveRegion, isUserRegion, selectedPoints });
-
 				if (
 					interactiveRegion &&
 					interactiveRegion !== InteractiveRegionOption.GRIDDED_DATA &&
@@ -257,9 +254,6 @@ const Steps: React.FC = () => {
 						dispatch(setRequestError('Failed to fetch region grid points'));
 						return;
 					}
-
-					console.log('RBx 1', { regionId, url });
-
 				} else if (selectedPoints && Object.keys(selectedPoints).length > 0) {
 					latList = Object.values(selectedPoints).map((c) => c.lat).join(',');
 					lonList = Object.values(selectedPoints).map((c) => c.lng).join(',');
@@ -270,9 +264,6 @@ const Steps: React.FC = () => {
 
 				if (isDailyRequest) {
 					const selectedRegion = climateVariable.getSelectedRegion();
-
-					console.log('RBx 2 isDailyRequest', selectedRegion);
-
 					if (selectedRegion) {
 						const bounds = selectedRegion.bounds as [
 							[number, number],
@@ -290,8 +281,6 @@ const Steps: React.FC = () => {
 							inputs.push({ id: 'lon0', data: lonList });
 						}
 					}
-
-					console.log('RBx 3', { inputs, isUserRegion });
 				} else if (!isUserRegion) {
 					// We don't include the lat and lon for user custom shapes
 					// (i.e. shapefile)
@@ -392,10 +381,10 @@ const Steps: React.FC = () => {
 					/**
 					 * outputName might look like, we have to escape paths:
 					 * - "tx_tn_days_above_health_North Shore/Coast Garibaldi Health Service Delivery Area"
+					 * - "tx_days_above_health_Tłı̨chǫ Community Services Agen"
 					 */
 					outputName = outputName
 												.replace(/[/\\]/g, '_');
-					console.log('RBx 4', outputName);
 					inputs.push({ id: 'output_name', data: outputName });
 				}
 
@@ -437,8 +426,6 @@ const Steps: React.FC = () => {
 				if (isDailyRequest) {
 					inputs.push({ id: 'variable', data: climateVariable.getFinch?.() || '' });
 				}
-
-				console.log('RBx 5 END', inputs);
 
 				const request_data: { [key: string]: any; } = {};
 				request_data['inputs'] = inputs;

--- a/apps/src/components/download/steps.tsx
+++ b/apps/src/components/download/steps.tsx
@@ -389,6 +389,12 @@ const Steps: React.FC = () => {
 							}
 						}
 					}
+					/**
+					 * outputName might look like, we have to escape paths:
+					 * - "tx_tn_days_above_health_North Shore/Coast Garibaldi Health Service Delivery Area"
+					 */
+					outputName = outputName
+												.replace(/[/\\]/g, '_');
 					console.log('RBx 4', outputName);
 					inputs.push({ id: 'output_name', data: outputName });
 				}

--- a/apps/src/components/download/steps.tsx
+++ b/apps/src/components/download/steps.tsx
@@ -234,6 +234,9 @@ const Steps: React.FC = () => {
 				let latList = '';
 				let lonList = '';
 
+
+				console.log('RBx 0', { interactiveRegion, isUserRegion, selectedPoints });
+
 				if (
 					interactiveRegion &&
 					interactiveRegion !== InteractiveRegionOption.GRIDDED_DATA &&
@@ -254,6 +257,9 @@ const Steps: React.FC = () => {
 						dispatch(setRequestError('Failed to fetch region grid points'));
 						return;
 					}
+
+					console.log('RBx 1', { regionId, url });
+
 				} else if (selectedPoints && Object.keys(selectedPoints).length > 0) {
 					latList = Object.values(selectedPoints).map((c) => c.lat).join(',');
 					lonList = Object.values(selectedPoints).map((c) => c.lng).join(',');
@@ -264,6 +270,9 @@ const Steps: React.FC = () => {
 
 				if (isDailyRequest) {
 					const selectedRegion = climateVariable.getSelectedRegion();
+
+					console.log('RBx 2 isDailyRequest', selectedRegion);
+
 					if (selectedRegion) {
 						const bounds = selectedRegion.bounds as [
 							[number, number],
@@ -281,6 +290,8 @@ const Steps: React.FC = () => {
 							inputs.push({ id: 'lon0', data: lonList });
 						}
 					}
+
+					console.log('RBx 3', { inputs, isUserRegion });
 				} else if (!isUserRegion) {
 					// We don't include the lat and lon for user custom shapes
 					// (i.e. shapefile)
@@ -378,6 +389,7 @@ const Steps: React.FC = () => {
 							}
 						}
 					}
+					console.log('RBx 4', outputName);
 					inputs.push({ id: 'output_name', data: outputName });
 				}
 
@@ -419,6 +431,8 @@ const Steps: React.FC = () => {
 				if (isDailyRequest) {
 					inputs.push({ id: 'variable', data: climateVariable.getFinch?.() || '' });
 				}
+
+				console.log('RBx 5 END', inputs);
 
 				const request_data: { [key: string]: any; } = {};
 				request_data['inputs'] = inputs;


### PR DESCRIPTION
## Description

On the **Download** page, requesting data for certain **Health Region** selections (`InteractiveRegionOption.HEALTH`) failed in Finch: the job errored, no file was produced, and the user received an error email instead of their data.

**Root cause.** The selected region's display name is sent to Finch as the `output_name` input — the label Finch uses to name the output file. Two of the 119 health-region names contain a forward slash:

- `North Shore/Coast Garibaldi Health Service Delivery Area`
- `Thompson/Cariboo Health Service Delivery Area`

Finch builds its output path from `output_name` and reads the `/` as a directory separator, so it attempts to write into a sub-directory that does not exist:

```
Finch failed with Cannot save file into a non-existent directory: tx_tn_days_above_health_North Shore
Finch failed with Errno 13 Permission denied: /code/tx_tn_days_above_health_North Shore/coast_garibaldi…
```

Two message variants across the failing jobs, one cause — the `/` split.

**Fix.** Before `output_name` is pushed to the Finch inputs, replace the path separators `/` and `\` with `_`:

```ts
outputName = outputName.replace(/[/\\]/g, '_');
```

`North Shore/Coast Garibaldi…` is then sent as `…North Shore_Coast Garibaldi…`, which Finch accepts and stores as `…north_shore_coast_garibaldi…` — matching a known-good run.

**Why only the slash.** Finch already normalizes the rest of the name itself — it lower-cases, replaces spaces and punctuation with `_`, ASCII-folds accents, and transliterates non-ASCII letters. Verified against real jobs:

- `Région de l'Estrie` was submitted **unescaped** (accent + apostrophe + spaces) and **succeeded**, returning `…region_de_l_estrie….zip`. So accents, apostrophes and dashes are not the cause.
- `Tłı̨chǫ Community Services Agen` (letters that do not NFKD-fold: `ł ı ǫ`) was also submitted **unescaped** and **succeeded**, returning `…tlicho_community_services_agen…` — Finch transliterates `ł→l`, `ı→i`, `ǫ→o` ([see on the map](https://donneesclimatiques.ca/cartes/?var=days_above_tmax&region=health&dataset=216&dataOpacity=100&labelOpacity=100&lat=61.49649&lng=-110.96191&zoom=6) click near '*Northwest Territories*').

- The slash is special only because Finch consumes it as a path separator **before** that normalization runs.

A scan of all 119 names in the GeoServer `CDC:health` layer found exactly **2** with `/` (the two above); the rest carry accents, dashes, apostrophes and even non-Latin letters — all of which Finch handles on its own. The slash fix therefore covers the failure for the entire layer.

**Scope & safety.**

- Download app only; the change touches only the assembled `output_name` string.
- `output_name` is write-only on the frontend (nothing reads it back), so this cannot affect request matching or any other input.
- Behaviour changes only for the 2 slash-bearing regions; every other region produces the same `output_name` as before.

> [!NOTE]
> Unrelated data note: `Tłı̨chǫ Community Services Agen…` (region `id` 116) is truncated in the `CDC:health` source layer (it should read "Agency"). It downloads correctly — Finch transliterates the name to `tlicho_community_services_agen` — so this is a separate layer data-quality issue.


## Related ticket

- CLIM-1339
<!-- w:CLIM-1339:2026060500 -->