### PR TITLE
CLIM-1393: Time series: Make 30-year selected by default + other fixes

### DIFF
--- a/apps/src/components/climate-data-chart.tsx
+++ b/apps/src/components/climate-data-chart.tsx
@@ -465,6 +465,8 @@ const ClimateDataChart: React.FC<{
 			}) || []
 		);
 
+		// Remove series without any data (else they would be shown in the
+		// legend but not in the chart).
 		return series.filter((s) => (s.data?.length ?? 0) > 0);
 	}, [activeTab, activeSeries, seriesObject]);
 

--- a/apps/src/components/climate-data-chart.tsx
+++ b/apps/src/components/climate-data-chart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Highcharts, {
 	numberFormat,
 	Options,
@@ -29,7 +29,18 @@ import { getChartDataOptions, getSeriesObject } from '@/config/chart-config';
 import { AveragingType } from "@/types/climate-variable-interface";
 import { trackGraphExport } from '@/lib/google-analytics';
 
-type TabValue = 'annual-values' | '30-year-averages' | '30-year-changes';
+/*
+ * Possible types of value aggregation on the chart. The value aggregation
+ * impacts only the value (i.e. popup) shown when hovering the graph, it doesn't
+ * impact the graph itself.
+ *
+ * - 'individual-values': The value of each individual point is shown.
+ * - 'period-averages': The average of the values of the period is shown (ex:
+ *     average over a 30-year period).
+ * - 'period-changes': The _difference_ between the period average (like
+ *     'period-averages') and a reference period.
+ */
+type TabValue = 'individual-values' | 'period-averages' | 'period-changes';
 
 interface Tab {
 	value: TabValue;
@@ -81,6 +92,59 @@ function addClimateZonePlotBands(options: Options) {
 }
 
 /**
+ * Return the aggregation tabs to be displayed.
+ *
+ * @param climateVariableId - The ID of the displayed variable.
+ * @param averagingOptions - The available averaging options for the variable.
+ */
+function getGraphTabs(climateVariableId: string, averagingOptions: AveragingType[]): Tab[] {
+	const isAllYearsAveragingEnabled = averagingOptions.includes(AveragingType.ALL_YEARS);
+	const isThirtyYearAveragingEnabled = averagingOptions.includes(AveragingType.THIRTY_YEARS);
+
+	const all_tabs: Tab[] = [
+		{
+			value: 'individual-values',
+			label: __('Annual values'),
+			enabled: isAllYearsAveragingEnabled,
+		},
+		{
+			value: 'period-averages',
+			label: __('30-year averages'),
+			enabled: isThirtyYearAveragingEnabled,
+		},
+		{
+			value: 'period-changes',
+			label: __('30-year changes'),
+			enabled: isThirtyYearAveragingEnabled,
+		},
+	];
+
+	if (climateVariableId === 'msc_climate_normals') {
+		return [all_tabs[0]];
+	}
+
+
+	return all_tabs;
+}
+
+/**
+ * Return which of the aggregation tab must be selected by default.
+ *
+ * @param tabs - The tabs available.
+ */
+function getDefaultActiveTab(tabs: Tab[]): TabValue {
+	// By default, we prioritize 'period-averages', if enabled.
+	const preferredDefaultTab = tabs.find((tab) => tab.value === 'period-averages');
+
+	if (preferredDefaultTab && preferredDefaultTab.enabled) {
+		return preferredDefaultTab.value;
+	}
+
+	// Else, we return the first enabled tab, or 'individual-values' as fallback.
+	return tabs.find((tab) => tab.enabled)?.value ?? 'individual-values';
+}
+
+/**
  * Component to render a chart using Highcharts with climate data.
  */
 const ClimateDataChart: React.FC<{
@@ -105,14 +169,28 @@ const ClimateDataChart: React.FC<{
 	const climateVariableId = climateVariable?.getId();
 	const version = climateVariable?.getVersion();
 	const unit = climateVariable?.getUnit();
+	const averagingOptions = climateVariable?.getAveragingOptions() ?? [];
 	const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+	// If the navigator shown below the graph is displayed
+	const enableChartNavigator = climateVariableId !== 'msc_climate_normals';
 
-	const [enableTabs, setEnableTabs] = useState(true);
-	const [activeTab, setActiveTab] = useState<TabValue>('annual-values');
+	// Aggregation tabs to display
+	const tabs: Tab[] = useMemo(() => {
+		if (climateVariableId == null) {
+			return [];
+		}
+
+		return getGraphTabs(climateVariableId, averagingOptions);
+	}, [climateVariableId, averagingOptions]);
+
+	// If we show the aggregation tabs
+	const enableTabs = tabs.length > 1;
+
+	// The currently selected tab.
+	const [activeTab, setActiveTab] = useState<TabValue>(() => getDefaultActiveTab(tabs));
 	const [activeSeries, setActiveSeries] = useState<string[]>([]);
 	const [activeChartTooltip, setActiveChartTooltip] = useState<Highcharts.TooltipOptions>({});
 	const [activeChartPlotOptions, setActiveChartPlotOptions] = useState<Highcharts.PlotOptions>({});
-	const [enableChartNavigator, setEnableChartNavigator] = useState(true);
 
 	// Subtitle displayed info
 	const datasetLabel = getLocalized(dataset) ?? '';
@@ -244,7 +322,7 @@ const ClimateDataChart: React.FC<{
 	// Chart tooltips
 	const chartTooltips = useMemo(() =>
 		() => ({
-			'annual-values': {
+			'individual-values': {
 				crosshairs: true,
 				shared: true,
 				split: false,
@@ -272,13 +350,13 @@ const ClimateDataChart: React.FC<{
 						}).join('') || '';
 				}
 			},
-			'30-year-averages': {
+			'period-averages': {
 				followPointer: true,
 				formatter: function (this: Point) {
 					return tooltip30yFormatter(this.x, '30y_', false, activeSeries);
 				},
 			},
-			'30-year-changes': {
+			'period-changes': {
 				followPointer: true,
 				formatter: function (this: Point) {
 					return tooltip30yFormatter(this.x, 'delta7100_', true, activeSeries);
@@ -291,7 +369,7 @@ const ClimateDataChart: React.FC<{
 	// Chart plot options
 	const chartPlotOptions = useMemo<() => Record<TabValue, Highcharts.PlotOptions>>(() =>
 		() => ({
-			'annual-values': {
+			'individual-values': {
 				series: {
 					states: {
 						hover: {
@@ -303,7 +381,7 @@ const ClimateDataChart: React.FC<{
 					},
 				},
 			},
-			'30-year-averages': {
+			'period-averages': {
 				series: {
 					states: {
 						hover: {
@@ -315,7 +393,7 @@ const ClimateDataChart: React.FC<{
 					},
 				},
 			},
-			'30-year-changes': {
+			'period-changes': {
 				series: {
 					states: {
 						hover: {
@@ -331,6 +409,20 @@ const ClimateDataChart: React.FC<{
 		[]
 	);
 
+	// When the list of tabs changes, validate that the active tab is still
+	// enabled, else change it to the default tab.
+	useEffect(() => {
+		setActiveTab((currentActiveTab) => {
+			const currentTab = tabs.find((tab) => tab.value === currentActiveTab);
+
+			if (currentTab?.enabled) {
+				return currentActiveTab;
+			}
+
+			return getDefaultActiveTab(tabs);
+		});
+	}, [tabs]);
+
 	// Update plot bands when the active tab changes
 	useEffect(() => {
 		// Chart reference
@@ -340,7 +432,7 @@ const ClimateDataChart: React.FC<{
 		chart.xAxis[0].removePlotBand('30y-plot-band',);
 		chart.xAxis[0].removePlotBand('delta-plot-band');
 
-		if(activeTab === '30-year-changes') {
+		if(activeTab === 'period-changes') {
 			// Add plot band for 30y changes
 			chart.xAxis[0].addPlotBand({
 				from: Date.UTC(1971, 0, 1),
@@ -374,13 +466,6 @@ const ClimateDataChart: React.FC<{
 		);
 	}, [activeTab, activeSeries, seriesObject]);
 
-	// Initialize enableTabs state based on the climate variable
-	useEffect(() => {
-		setEnableTabs(climateVariableId !== 'msc_climate_normals');
-		setEnableChartNavigator(climateVariableId !== 'msc_climate_normals');
-	}
-	, [climateVariableId]);
-
 	// initialize activeSeries state with all leys  from the first tab
 	useEffect(() => {
 		setActiveSeries(seriesObject.map((s) => s.custom?.key) || []);
@@ -405,31 +490,6 @@ const ClimateDataChart: React.FC<{
 			__(versionLabel),
 		].filter(Boolean).join('-'));
 	};
-
-	// Tabs configuration
-	const isThirtyYearAveragingEnabled = useCallback(() => {
-		const averagingOptions = climateVariable?.getAveragingOptions() ?? [];
-		return averagingOptions.length > 0 && averagingOptions.includes(AveragingType.THIRTY_YEARS);
-	}, [climateVariable]);
-
-	// Tabs configuration
-	const tabs: Tab[] = useMemo(() => [
-		{
-			value: 'annual-values',
-			label: __('Annual values'),
-			enabled: true,
-		},
-		{
-			value: '30-year-averages',
-			label: __('30-year averages'),
-			enabled: isThirtyYearAveragingEnabled(),
-		},
-		{
-			value: '30-year-changes',
-			label: __('30-year changes'),
-			enabled: isThirtyYearAveragingEnabled(),
-		},
-	], [isThirtyYearAveragingEnabled, __]);
 
 	// Chart options
 	const chartOptions = useMemo<Options>(() => {
@@ -586,7 +646,7 @@ const ClimateDataChart: React.FC<{
 						opacity: 0.6,
 						states: {
 							hover: {
-								enabled: activeTab === 'annual-values',
+								enabled: activeTab === 'individual-values',
 								lineWidth: 0,
 								opacity: 0,
 							},
@@ -756,7 +816,7 @@ const ClimateDataChart: React.FC<{
 								}
 							}
 
-							if(activeTab === 'annual-values') {
+							if(activeTab === 'individual-values') {
 								chart.downloadCSV();
 							} else {
 								const prefixes: string[] = ['30y_', 'delta7100_'];

--- a/apps/src/components/climate-data-chart.tsx
+++ b/apps/src/components/climate-data-chart.tsx
@@ -445,7 +445,7 @@ const ClimateDataChart: React.FC<{
 
 	// adds visible property to each series
 	const filteredSeries = useMemo<SeriesOptionsType[]>(() => {
-		return (
+		const series = (
 			seriesObject.map((s) => {
 				const baseSeries = {
 					...s,
@@ -464,6 +464,8 @@ const ClimateDataChart: React.FC<{
 				}
 			}) || []
 		);
+
+		return series.filter((s) => (s.data?.length ?? 0) > 0);
 	}, [activeTab, activeSeries, seriesObject]);
 
 	// initialize activeSeries state with all leys  from the first tab

--- a/apps/src/components/climate-data-chart.tsx
+++ b/apps/src/components/climate-data-chart.tsx
@@ -34,13 +34,19 @@ import { trackGraphExport } from '@/lib/google-analytics';
  * impacts only the value (i.e. popup) shown when hovering the graph, it doesn't
  * impact the graph itself.
  *
- * - 'individual-values': The value of each individual point is shown.
- * - 'period-averages': The average of the values of the period is shown (ex:
+ * - INDIVIDUAL_VALUES: The value of each individual point is shown.
+ * - PERIOD_AVERAGES: The average of the values of the period is shown (ex:
  *     average over a 30-year period).
- * - 'period-changes': The _difference_ between the period average (like
- *     'period-averages') and a reference period.
+ * - PERIOD_CHANGES: The _difference_ between the period average (like
+ *     PERIOD_AVERAGES) and a reference period.
  */
-type TabValue = 'individual-values' | 'period-averages' | 'period-changes';
+const TAB_VALUES = {
+	INDIVIDUAL_VALUES: 'individual-values',
+	PERIOD_AVERAGES:   'period-averages',
+	PERIOD_CHANGES:    'period-changes',
+} as const;
+
+type TabValue = typeof TAB_VALUES[keyof typeof TAB_VALUES];
 
 interface Tab {
 	value: TabValue;
@@ -103,17 +109,17 @@ function getGraphTabs(climateVariable: ClimateVariableInterface): Tab[] {
 
 	const allTabs: Tab[] = [
 		{
-			value: 'individual-values',
+			value: TAB_VALUES.INDIVIDUAL_VALUES,
 			label: __('Annual values'),
 			enabled: isAllYearsAveragingEnabled,
 		},
 		{
-			value: 'period-averages',
+			value: TAB_VALUES.PERIOD_AVERAGES,
 			label: __('30-year averages'),
 			enabled: isThirtyYearAveragingEnabled,
 		},
 		{
-			value: 'period-changes',
+			value: TAB_VALUES.PERIOD_CHANGES,
 			label: __('30-year changes'),
 			enabled: isThirtyYearAveragingEnabled,
 		},
@@ -121,7 +127,7 @@ function getGraphTabs(climateVariable: ClimateVariableInterface): Tab[] {
 
 	if (climateVariable.getId() === 'msc_climate_normals') {
 		// We use `filter` because we want to return an array of tabs.
-		return allTabs.filter((tab) => tab.value === 'individual-values');
+		return allTabs.filter((tab) => tab.value === TAB_VALUES.INDIVIDUAL_VALUES);
 	}
 
 	return allTabs;
@@ -133,15 +139,15 @@ function getGraphTabs(climateVariable: ClimateVariableInterface): Tab[] {
  * @param tabs - The tabs available.
  */
 function getDefaultActiveTab(tabs: Tab[]): TabValue {
-	// By default, we prioritize 'period-averages', if enabled.
-	const preferredDefaultTab = tabs.find((tab) => tab.value === 'period-averages');
+	// By default, we prioritize PERIOD_AVERAGES, if enabled.
+	const preferredDefaultTab = tabs.find((tab) => tab.value === TAB_VALUES.PERIOD_AVERAGES);
 
 	if (preferredDefaultTab && preferredDefaultTab.enabled) {
 		return preferredDefaultTab.value;
 	}
 
-	// Else, we return the first enabled tab, or 'individual-values' as fallback.
-	return tabs.find((tab) => tab.enabled)?.value ?? 'individual-values';
+	// Else, we return the first enabled tab, or INDIVIDUAL_VALUES as fallback.
+	return tabs.find((tab) => tab.enabled)?.value ?? TAB_VALUES.INDIVIDUAL_VALUES;
 }
 
 /**
@@ -321,7 +327,7 @@ const ClimateDataChart: React.FC<{
 	// Chart tooltips
 	const chartTooltips = useMemo(() =>
 		() => ({
-			'individual-values': {
+			[TAB_VALUES.INDIVIDUAL_VALUES]: {
 				crosshairs: true,
 				shared: true,
 				split: false,
@@ -349,13 +355,13 @@ const ClimateDataChart: React.FC<{
 						}).join('') || '';
 				}
 			},
-			'period-averages': {
+			[TAB_VALUES.PERIOD_AVERAGES]: {
 				followPointer: true,
 				formatter: function (this: Point) {
 					return tooltipPeriodFormatter(this.x, '30y_', false, activeSeries);
 				},
 			},
-			'period-changes': {
+			[TAB_VALUES.PERIOD_CHANGES]: {
 				followPointer: true,
 				formatter: function (this: Point) {
 					return tooltipPeriodFormatter(this.x, 'delta7100_', true, activeSeries);
@@ -368,7 +374,7 @@ const ClimateDataChart: React.FC<{
 	// Chart plot options
 	const chartPlotOptions = useMemo<() => Record<TabValue, Highcharts.PlotOptions>>(() =>
 		() => ({
-			'individual-values': {
+			[TAB_VALUES.INDIVIDUAL_VALUES]: {
 				series: {
 					states: {
 						hover: {
@@ -380,7 +386,7 @@ const ClimateDataChart: React.FC<{
 					},
 				},
 			},
-			'period-averages': {
+			[TAB_VALUES.PERIOD_AVERAGES]: {
 				series: {
 					states: {
 						hover: {
@@ -392,7 +398,7 @@ const ClimateDataChart: React.FC<{
 					},
 				},
 			},
-			'period-changes': {
+			[TAB_VALUES.PERIOD_CHANGES]: {
 				series: {
 					states: {
 						hover: {
@@ -431,7 +437,7 @@ const ClimateDataChart: React.FC<{
 		chart.xAxis[0].removePlotBand('period-plot-band',);
 		chart.xAxis[0].removePlotBand('delta-plot-band');
 
-		if(activeTab === 'period-changes') {
+		if(activeTab === TAB_VALUES.PERIOD_CHANGES) {
 			// Add plot band for reference period changes
 			chart.xAxis[0].addPlotBand({
 				from: Date.UTC(1971, 0, 1),
@@ -649,7 +655,7 @@ const ClimateDataChart: React.FC<{
 						opacity: 0.6,
 						states: {
 							hover: {
-								enabled: activeTab === 'individual-values',
+								enabled: activeTab === TAB_VALUES.INDIVIDUAL_VALUES,
 								lineWidth: 0,
 								opacity: 0,
 							},
@@ -819,7 +825,7 @@ const ClimateDataChart: React.FC<{
 								}
 							}
 
-							if(activeTab === 'individual-values') {
+							if(activeTab === TAB_VALUES.INDIVIDUAL_VALUES) {
 								chart.downloadCSV();
 							} else {
 								const prefixes: string[] = ['30y_', 'delta7100_'];

--- a/apps/src/components/climate-data-chart.tsx
+++ b/apps/src/components/climate-data-chart.tsx
@@ -26,7 +26,7 @@ import { useClimateVariable } from "@/hooks/use-climate-variable";
 import appConfig from '@/config/app.config';
 import { doyFormatter, formatValue } from '@/lib/format';
 import { getChartDataOptions, getSeriesObject } from '@/config/chart-config';
-import { AveragingType } from "@/types/climate-variable-interface";
+import { AveragingType, ClimateVariableInterface } from '@/types/climate-variable-interface';
 import { trackGraphExport } from '@/lib/google-analytics';
 
 /*
@@ -94,14 +94,14 @@ function addClimateZonePlotBands(options: Options) {
 /**
  * Return the aggregation tabs to be displayed.
  *
- * @param climateVariableId - The ID of the displayed variable.
- * @param averagingOptions - The available averaging options for the variable.
+ * @param climateVariable - The displayed climate variable.
  */
-function getGraphTabs(climateVariableId: string, averagingOptions: AveragingType[]): Tab[] {
+function getGraphTabs(climateVariable: ClimateVariableInterface): Tab[] {
+	const averagingOptions = climateVariable.getAveragingOptions();
 	const isAllYearsAveragingEnabled = averagingOptions.includes(AveragingType.ALL_YEARS);
 	const isThirtyYearAveragingEnabled = averagingOptions.includes(AveragingType.THIRTY_YEARS);
 
-	const all_tabs: Tab[] = [
+	const allTabs: Tab[] = [
 		{
 			value: 'individual-values',
 			label: __('Annual values'),
@@ -119,12 +119,12 @@ function getGraphTabs(climateVariableId: string, averagingOptions: AveragingType
 		},
 	];
 
-	if (climateVariableId === 'msc_climate_normals') {
-		return [all_tabs[0]];
+	if (climateVariable.getId() === 'msc_climate_normals') {
+		// We use `filter` because we want to return an array of tabs.
+		return allTabs.filter((tab) => tab.value === 'individual-values');
 	}
 
-
-	return all_tabs;
+	return allTabs;
 }
 
 /**
@@ -169,19 +169,18 @@ const ClimateDataChart: React.FC<{
 	const climateVariableId = climateVariable?.getId();
 	const version = climateVariable?.getVersion();
 	const unit = climateVariable?.getUnit();
-	const averagingOptions = climateVariable?.getAveragingOptions() ?? [];
 	const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 	// If the navigator shown below the graph is displayed
 	const enableChartNavigator = climateVariableId !== 'msc_climate_normals';
 
 	// Aggregation tabs to display
 	const tabs: Tab[] = useMemo(() => {
-		if (climateVariableId == null) {
+		if (climateVariable == null) {
 			return [];
 		}
 
-		return getGraphTabs(climateVariableId, averagingOptions);
-	}, [climateVariableId, averagingOptions]);
+		return getGraphTabs(climateVariable);
+	}, [climateVariable]);
 
 	// If we show the aggregation tabs
 	const enableTabs = tabs.length > 1;
@@ -235,7 +234,7 @@ const ClimateDataChart: React.FC<{
 	// Get the label for the current threshold, or null if not found.
 	const thresholdLabel = getLabelByValue(threshold);
 
-	// Tooltip: find closest timestamp for 30-years options
+	// Tooltip: find closest timestamp for period options
 	const findClosetTimestamp = (timestamp: number, data: Record<string, number[]> | undefined) => {
 		if (!data) return null;
 		const sortedKeys = Object.keys(data)
@@ -254,15 +253,15 @@ const ClimateDataChart: React.FC<{
 		[data, version, climateVariableId, chartDataOptions]
 	);
 
-	// Tooltip formatter for 30-years averages and changes
-	const tooltip30yFormatter = (x: number, prefix: string, isDelta: boolean, currentActiveSeries: string[]) => {
+	// Tooltip formatter for period averages and changes
+	const tooltipPeriodFormatter = (x: number, prefix: string, isDelta: boolean, currentActiveSeries: string[]) => {
 		// Chart reference
 		const chart = chartRef.current?.chart;
 		if (!chart) {
 			return false;
 		}
 		// Remove previous plot band
-		chart.xAxis[0].removePlotBand('30y-plot-band',);
+		chart.xAxis[0].removePlotBand('period-plot-band');
 
 		// Get current range
 		const currentTimestamp = x;
@@ -281,11 +280,11 @@ const ClimateDataChart: React.FC<{
 		const startYear = new Date(timestampKey).getUTCFullYear();
 		const endYear = startYear + 29;
 
-		// Add plot band on 30-years range
+		// Add plot band on period range
 		chart.xAxis[0].addPlotBand({
 			from: Date.UTC(startYear, 0, 1),
 			to: Date.UTC(startYear + 29, 11, 31),
-			id: '30y-plot-band',
+			id: 'period-plot-band',
 			color: 'rgba(51,63,80,0.1)',
 		});
 
@@ -294,7 +293,7 @@ const ClimateDataChart: React.FC<{
 		if(prefix === "delta7100_") tooltip += ` (${__('Change from ')} 1971-2000)`;
 		tooltip += `</b><br/>`;
 
-		// Iterate on 30y data
+		// Iterate on period data
 		Object.keys(data)
 			.filter((key) => key.startsWith(prefix))
 			.forEach((key) => {
@@ -353,13 +352,13 @@ const ClimateDataChart: React.FC<{
 			'period-averages': {
 				followPointer: true,
 				formatter: function (this: Point) {
-					return tooltip30yFormatter(this.x, '30y_', false, activeSeries);
+					return tooltipPeriodFormatter(this.x, '30y_', false, activeSeries);
 				},
 			},
 			'period-changes': {
 				followPointer: true,
 				formatter: function (this: Point) {
-					return tooltip30yFormatter(this.x, 'delta7100_', true, activeSeries);
+					return tooltipPeriodFormatter(this.x, 'delta7100_', true, activeSeries);
 				},
 			},
 		}),
@@ -429,11 +428,11 @@ const ClimateDataChart: React.FC<{
 		const chart = chartRef.current?.chart;
 		if (!chart) return;
 		// Remove previous plot bands when we change tab
-		chart.xAxis[0].removePlotBand('30y-plot-band',);
+		chart.xAxis[0].removePlotBand('period-plot-band',);
 		chart.xAxis[0].removePlotBand('delta-plot-band');
 
 		if(activeTab === 'period-changes') {
-			// Add plot band for 30y changes
+			// Add plot band for reference period changes
 			chart.xAxis[0].addPlotBand({
 				from: Date.UTC(1971, 0, 1),
 				to: Date.UTC(2000, 11, 31),


### PR DESCRIPTION
**Context:** currently, in the Maps page, when opening the time series graph, the default selected tab is the "Annual values".

**Problem:** The tab "30-year averages" should be the one selected by default.

**This PR**

This PR makes the default tab to be "30-year averages".

But this PR also uses the chance to improve a little bit the code of the time series graph panel:

* The concept "annual values" is renamed "individual values" which better reflects what this tab is actually doing (but the tab's text is not changed).
* For the same reason, the concept "30 year values" is renamed to "period values", removing possible confusion if we ever get a period of other than 30 years (but the tab's text has not been changed).
* The default tab is "30-year averages", but there is now a fallback if it's not enabled/available.
* A small issue was fixed: some variables don't have data for all the series (ex: Humidex doesn't have SSP3-7.0), but the series' name is still shown in the legend. The issue is fixed by removing series that don't have any data.

## Related issue

CLIM-1393