### PR TITLE
CLIM-1413: fix missing delta value for return periods

### DIFF
--- a/apps/src/components/map-layers/raster-precalculated-climate-variable-values.tsx
+++ b/apps/src/components/map-layers/raster-precalculated-climate-variable-values.tsx
@@ -58,6 +58,7 @@ const RasterPrecalcultatedClimateVariableValues: React.FC<RasterPrecalcultatedCl
 		const variable = climateVariable?.getThreshold() ?? '';
 		const { lat, lng } = latlng;
 		const decadeValue = parseInt(dateRange[0]) - (parseInt(dateRange[0]) % 10) + 1;
+		const isReturnPeriod = climateVariable?.getClass() === 'ReturnPeriodClimateVariable';
 
 		const fetchData = async () => {
 			if (!decadeValue && !variableId) return;
@@ -154,7 +155,6 @@ const RasterPrecalcultatedClimateVariableValues: React.FC<RasterPrecalcultatedCl
 				else if(frequency == 'winter') month = 11;
 			}
 
-			const isReturnPeriod = climateVariable?.getClass() === 'ReturnPeriodClimateVariable';
 			const lookupYear = isReturnPeriod ? decadeValue + 15 : decadeValue;
 			const timestamp = Date.UTC(lookupYear, month, 1, 0, 0, 0);
 

--- a/apps/src/components/map-layers/raster-precalculated-climate-variable-values.tsx
+++ b/apps/src/components/map-layers/raster-precalculated-climate-variable-values.tsx
@@ -154,7 +154,9 @@ const RasterPrecalcultatedClimateVariableValues: React.FC<RasterPrecalcultatedCl
 				else if(frequency == 'winter') month = 11;
 			}
 
-			const timestamp = Date.UTC(decadeValue, month, 1, 0, 0, 0);
+			const isReturnPeriod = climateVariable?.getClass() === 'ReturnPeriodClimateVariable';
+			const lookupYear = isReturnPeriod ? decadeValue + 15 : decadeValue;
+			const timestamp = Date.UTC(lookupYear, month, 1, 0, 0, 0);
 
 			if(
 				chartsData[deltaValueKey] !== undefined


### PR DESCRIPTION
## Description

Delta values were missing from the grid cell popup. This is because charts data for return periods have a 15 year offset, and the delta value was selected with specific datetimes, in this case, the first year of every decade, like for other variables. This wasn't taking in account the offset of return periods values, and detected no data available for the requested year.

## Related ticket

[CLIM-1413](https://ccdpwiki.atlassian.net/browse/CLIM-1413)


[CLIM-1413]: https://ccdpwiki.atlassian.net/browse/CLIM-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ