### PR TITLE
Minor return periods chart fix

### DIFF
--- a/apps/src/components/climate-data-chart.tsx
+++ b/apps/src/components/climate-data-chart.tsx
@@ -244,7 +244,7 @@ function getSeriesXValues(allSeries: Series[]): number[] {
 	return xValues;
 }
 
-const FIFTEEN_YEARS = 15 * 365 * 24 * 60 * 60 * 1000;
+const RETURN_PERIOD_PLOTBAND_YEAR_LENGTH = 9;
 
 /**
  * Component to render a chart using Highcharts with climate data.
@@ -389,10 +389,9 @@ const ClimateDataChart: React.FC<{
 		let plotBandYearLength = 29;
 
 		if (isReturnPeriod) {
-			// Return period uses smaller plotband, with data offsetted by 15 years, since it uses a different chart type
-			tooltipStartYear -= 15;
-			plotBandStartYear -= 5;
-			plotBandYearLength = 9;
+			// Return period uses a different plotband centered on the data point, adapted to its specific chart type
+			plotBandYearLength = RETURN_PERIOD_PLOTBAND_YEAR_LENGTH;
+			plotBandStartYear -= Math.ceil(plotBandYearLength / 2);
 		}
 
 		const tooltipEndYear = tooltipStartYear + tooltipYearLength;
@@ -555,9 +554,9 @@ const ClimateDataChart: React.FC<{
 			let plotbandEndYear = 2000;
 
 			if (isReturnPeriod) {
-				// Return period uses smaller plotband, with data offsetted by 15 years, since it uses a different chart type
-				plotbandStartYear = 1981;
-				plotbandEndYear = 1990;
+				// Return period uses a different plotband centered on the data point, adapted to its specific chart type
+				plotbandStartYear -= Math.ceil(RETURN_PERIOD_PLOTBAND_YEAR_LENGTH / 2);
+				plotbandEndYear = plotbandStartYear + RETURN_PERIOD_PLOTBAND_YEAR_LENGTH;
 			}
 
 			chart.xAxis[0].addPlotBand({
@@ -633,7 +632,7 @@ const ClimateDataChart: React.FC<{
 
 		return function() {
 			const valueDate = new Date(this.value);
-			const startYear = valueDate.getUTCFullYear() - 15;
+			const startYear = valueDate.getUTCFullYear();
 			const endYear = startYear + 29;
 
 			return `${startYear}&nbsp;-<br>${endYear}`;
@@ -879,26 +878,6 @@ const ClimateDataChart: React.FC<{
 		return options;
 	}, [climateVariable, climateVariableId, locale, title, filteredSeries, activeChartTooltip, activeChartPlotOptions]);
 
-	/*
-	 * For the Return Period variable, we extend the X-axis to allow the
-	 * period's gray block to be fully shown at extremities.
-	 */
-	useEffect(() => {
-		const chart = chartRef.current?.chart;
-
-		if (!chart || !isReturnPeriod || !activeTab.startsWith('period')) {
-			return;
-		}
-
-		// Timeout of 0 to allow the HighChart component to render before
-		// extending the X-axis.
-		const timeoutId = window.setTimeout(() => {
-			extendChartXAxis(chart, FIFTEEN_YEARS, FIFTEEN_YEARS);
-		}, 0);
-
-		return () => window.clearTimeout(timeoutId);
-	}, [chartOptions, isReturnPeriod, activeTab]);
-
 	// Export CSV from data
 	const exportCsvFromData = (data: Record<string, Record<string, number[]>>): string => {
 		// Get all ranges
@@ -1050,9 +1029,7 @@ const ClimateDataChart: React.FC<{
 										acc[newKey] = Object.fromEntries(
 											Object.entries(dataCopy[key] ?? {}).map(([timestamp, value]) => {
 												const year = new Date(Number(timestamp)).getUTCFullYear();
-												const startYear = isReturnPeriod ? year - 15 : year;
-												const endYear = startYear + 29;
-												return [`${startYear} - ${endYear}`, value as number[]];
+												return [`${year} - ${year + 29}`, value as number[]];
 											})
 										);
 										return acc;

--- a/apps/src/components/climate-data-chart.tsx
+++ b/apps/src/components/climate-data-chart.tsx
@@ -103,44 +103,6 @@ function addClimateZonePlotBands(options: Options) {
 }
 
 /**
- * Add an extra padding to the X-axis.
- *
- * This method should be called after the chart has rendered, to be able to
- * retrieve the current maximum values of the axis.
- *
- * @param chart - The chart to extend
- * @param extraStart - Additional padding to add at the beginning of the axe
- * @param extraEnd - Additional padding to add at the end of the axe
- */
-function extendChartXAxis(
-	chart: Chart,
-	extraStart: number|undefined,
-	extraEnd: number|undefined,
-) {
-	const xAxis = chart.xAxis[0];
-
-	if (!xAxis) {
-		return;
-	}
-
-	// By default, we reset the extremes
-	let newMin: number|undefined = undefined;
-	let newMax: number|undefined = undefined;
-
-	const { dataMin, dataMax } = xAxis.getExtremes();
-
-	if (extraStart) {
-		newMin = dataMin - extraStart;
-	}
-
-	if (extraEnd) {
-		newMax = dataMax + extraEnd;
-	}
-
-	xAxis.setExtremes(newMin, newMax);
-}
-
-/**
  * Return the aggregation tabs to be displayed.
  *
  * @param climateVariable - The displayed climate variable.
@@ -383,9 +345,9 @@ const ClimateDataChart: React.FC<{
 		}
 
 		// Displayed period
-		let tooltipStartYear = new Date(timestampKey).getUTCFullYear();
+		const tooltipStartYear = new Date(timestampKey).getUTCFullYear();
 		let plotBandStartYear = tooltipStartYear;
-		let tooltipYearLength = 29;
+		const tooltipYearLength = 29;
 		let plotBandYearLength = 29;
 
 		if (isReturnPeriod) {
@@ -566,7 +528,7 @@ const ClimateDataChart: React.FC<{
 				id: 'delta-plot-band',
 			});
 		}
-	}, [activeTab]);
+	}, [activeTab, isReturnPeriod]);
 
 	// adds visible property to each series
 	const filteredSeries = useMemo<SeriesOptionsType[]>(() => {

--- a/apps/src/components/climate-data-chart.tsx
+++ b/apps/src/components/climate-data-chart.tsx
@@ -321,7 +321,7 @@ const ClimateDataChart: React.FC<{
 			const firstDayIsJuly = actualUnit === 'DoY-jul';
 			return doyFormatter(value, locale, firstDayIsJuly);
 		}
-		
+
 		if (isRangeStart) {
 			actualUnit = '';
 		}
@@ -383,24 +383,31 @@ const ClimateDataChart: React.FC<{
 		}
 
 		// Displayed period
-		let startYear = new Date(timestampKey).getUTCFullYear();
+		let tooltipStartYear = new Date(timestampKey).getUTCFullYear();
+		let plotBandStartYear = tooltipStartYear;
+		let tooltipYearLength = 29;
+		let plotBandYearLength = 29;
 
 		if (isReturnPeriod) {
-			startYear -= 15;
+			// Return period uses smaller plotband, with data offsetted by 15 years, since it uses a different chart type
+			tooltipStartYear -= 15;
+			plotBandStartYear -= 5;
+			plotBandYearLength = 9;
 		}
 
-		const endYear = startYear + 29;
+		const tooltipEndYear = tooltipStartYear + tooltipYearLength;
+		const plotBandEndYear = plotBandStartYear + plotBandYearLength;
 
 		// Add plot band on period range
 		chart.xAxis[0].addPlotBand({
-			from: Date.UTC(startYear, 0, 1),
-			to: Date.UTC(endYear, 11, 31),
+			from: Date.UTC(plotBandStartYear, 0, 1),
+			to: Date.UTC(plotBandEndYear, 11, 31),
 			id: 'period-plot-band',
 			color: 'rgba(51,63,80,0.1)',
 		});
 
 		// Tooltip content
-		let tooltip = `<b>${startYear} - ${endYear}`;
+		let tooltip = `<b>${tooltipStartYear} - ${tooltipEndYear}`;
 		if(prefix === "delta7100_") tooltip += ` (${__('Change from ')} 1971-2000)`;
 		tooltip += `</b><br/>`;
 
@@ -544,9 +551,18 @@ const ClimateDataChart: React.FC<{
 
 		if(activeTab === TAB_VALUES.PERIOD_CHANGES) {
 			// Add plot band for reference period changes
+			let plotbandStartYear = 1971;
+			let plotbandEndYear = 2000;
+
+			if (isReturnPeriod) {
+				// Return period uses smaller plotband, with data offsetted by 15 years, since it uses a different chart type
+				plotbandStartYear = 1981;
+				plotbandEndYear = 1990;
+			}
+
 			chart.xAxis[0].addPlotBand({
-				from: Date.UTC(1971, 0, 1),
-				to: Date.UTC(2000, 11, 31),
+				from: Date.UTC(plotbandStartYear, 0, 1),
+				to: Date.UTC(plotbandEndYear, 11, 31),
 				color: 'rgba(51,63,80,0.05)',
 				id: 'delta-plot-band',
 			});
@@ -1185,8 +1201,8 @@ const ClimateDataChart: React.FC<{
 								'Canadian Centre for Climate Services</a> and the ' +
 								'<a href="https://climate.weather.gc.ca/climate_normals/index_e.html" %s>' +
 								'Government of Canada Historical Climate Data</a> websites.'
-							), 
-							'target="_blank" rel="noopener noreferrer" class="text-dark-purple"', 
+							),
+							'target="_blank" rel="noopener noreferrer" class="text-dark-purple"',
 							'target="_blank" rel="noopener noreferrer" class="text-dark-purple"',
 						)
 				}}

--- a/apps/src/components/map-layers/raster-precalculated-climate-variable-values.tsx
+++ b/apps/src/components/map-layers/raster-precalculated-climate-variable-values.tsx
@@ -58,7 +58,6 @@ const RasterPrecalcultatedClimateVariableValues: React.FC<RasterPrecalcultatedCl
 		const variable = climateVariable?.getThreshold() ?? '';
 		const { lat, lng } = latlng;
 		const decadeValue = parseInt(dateRange[0]) - (parseInt(dateRange[0]) % 10) + 1;
-		const isReturnPeriod = climateVariable?.getClass() === 'ReturnPeriodClimateVariable';
 
 		const fetchData = async () => {
 			if (!decadeValue && !variableId) return;
@@ -155,8 +154,7 @@ const RasterPrecalcultatedClimateVariableValues: React.FC<RasterPrecalcultatedCl
 				else if(frequency == 'winter') month = 11;
 			}
 
-			const lookupYear = isReturnPeriod ? decadeValue + 15 : decadeValue;
-			const timestamp = Date.UTC(lookupYear, month, 1, 0, 0, 0);
+			const timestamp = Date.UTC(decadeValue, month, 1, 0, 0, 0);
 
 			if(
 				chartsData[deltaValueKey] !== undefined


### PR DESCRIPTION
## Description

Minor fixes following partners feedback on return period data chart display:
- Trims grey plotband displayed on charts to be 10 years wide instead of 30 years
- Removes extra padding added at the beginning and end of x-axis
- Adapted to code to removed offset from the API, since it isn't needed anymore for the new chart format
