### PR TITLE
remove return period variables from all-candcs-variables

### DIFF
--- a/apps/src/config/climate-variables.config.ts
+++ b/apps/src/config/climate-variables.config.ts
@@ -1739,14 +1739,6 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 		],
 		unit: "degC",
 		unitDecimalPlaces: 1,
-		preCalculatedCanDCSConfig: {
-			rl5tasmax: [FrequencyType.YS],
-			rl10tasmax: [FrequencyType.YS],
-			rl20tasmax: [FrequencyType.YS],
-			rl25tasmax: [FrequencyType.YS],
-			rl30tasmax: [FrequencyType.YS],
-			rl50tasmax: [FrequencyType.YS],
-		},
 	},
 	/** 1-in-X-Year Annual Minimum Temperature (Return Level) */
 	{
@@ -1780,14 +1772,6 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 		],
 		unit: "degC",
 		unitDecimalPlaces: 1,
-		preCalculatedCanDCSConfig: {
-			rl5tasmin: [FrequencyType.YS],
-			rl10tasmin: [FrequencyType.YS],
-			rl20tasmin: [FrequencyType.YS],
-			rl25tasmin: [FrequencyType.YS],
-			rl30tasmin: [FrequencyType.YS],
-			rl50tasmin: [FrequencyType.YS],
-		},
 	},
 	/** 1-in-X-Year Annual Maximum 1-Day Precipitation (Return Level) */
 	{
@@ -1820,14 +1804,6 @@ export const ClimateVariables: ClimateVariableConfigInterface[] = [
 			},
 		],
 		unit: "mm",
-		preCalculatedCanDCSConfig: {
-			rl5pr: [FrequencyType.YS],
-			rl10pr: [FrequencyType.YS],
-			rl20pr: [FrequencyType.YS],
-			rl25pr: [FrequencyType.YS],
-			rl30pr: [FrequencyType.YS],
-			rl50pr: [FrequencyType.YS],
-		},
 	},
 	/** Relative Sea-Level Change */
 	{


### PR DESCRIPTION
Quick fix for return period variables which were causing a bug with `all-candcs-variables` when trying to download them. Since return period variables don't have annual values, it would cause an error when downloading annual values for `all-candcs-variables`, so return period variables have been excluded from them for now.
